### PR TITLE
feat: allow runtime OpenAI API key

### DIFF
--- a/api/assistant-reply.ts
+++ b/api/assistant-reply.ts
@@ -21,18 +21,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       post?: { id?: string | number; title?: string; text?: string };
     };
   };
+  const headerKey =
+    typeof req.headers.authorization === "string"
+      ? req.headers.authorization.replace(/^Bearer\s+/i, "")
+      : undefined;
 
-  // In production, only the server env is used. In local/dev, allow body.apiKey as a fallback.
-  const isProd = !!process.env.VERCEL || process.env.NODE_ENV === "production";
-  const apiKey = isProd
-    ? (process.env.OPENAI_API_KEY || "")
-    : (process.env.OPENAI_API_KEY || body.apiKey || "");
+  const apiKey = body.apiKey || headerKey || process.env.OPENAI_API_KEY || "";
 
   if (!apiKey) {
     return res.status(401).json({
       ok: false,
       error:
-        "Unauthorized: missing OPENAI_API_KEY on the server. Set it in Vercel → Settings → Environment Variables.",
+        "Unauthorized: missing OpenAI API key. Provide one in the request or set OPENAI_API_KEY on the server.",
     });
   }
 

--- a/api/openai-ping.ts
+++ b/api/openai-ping.ts
@@ -3,7 +3,13 @@ import type { VercelRequest, VercelResponse } from "@vercel/node";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== "POST") return res.status(405).json({ ok: false, error: "Method not allowed" });
-  const { apiKey } = (req.body || {});
+
+  const body = (req.body || {}) as { apiKey?: string };
+  const headerKey =
+    typeof req.headers.authorization === "string"
+      ? req.headers.authorization.replace(/^Bearer\s+/i, "")
+      : undefined;
+  const apiKey = body.apiKey || headerKey || process.env.OPENAI_API_KEY;
   if (!apiKey) return res.status(400).json({ ok: false, error: "Missing apiKey" });
 
   try {

--- a/api/openai-quick-chat.ts
+++ b/api/openai-quick-chat.ts
@@ -3,7 +3,14 @@ import type { VercelRequest, VercelResponse } from "@vercel/node";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== "POST") return res.status(405).json({ ok: false, error: "Method not allowed" });
-  const { apiKey } = (req.body || {});
+
+  const body = (req.body || {}) as { apiKey?: string };
+  const headerKey =
+    typeof req.headers.authorization === "string"
+      ? req.headers.authorization.replace(/^Bearer\s+/i, "")
+      : undefined;
+  const apiKey = body.apiKey || headerKey || process.env.OPENAI_API_KEY;
+
   if (!apiKey) return res.status(400).json({ ok: false, error: "Missing apiKey" });
 
   try {


### PR DESCRIPTION
## Summary
- let API routes accept OpenAI keys from request body or Authorization header with environment fallback
- use unified key retrieval across assist, assistant-reply, quick-chat, and ping endpoints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f4fa04648321a4f48a4e8538f2ad