### PR TITLE
feat: make super user key configurable and persistent

### DIFF
--- a/src/components/PostComposer.tsx
+++ b/src/components/PostComposer.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import "./PostComposer.css";
 import { useFeedStore } from "../lib/feedStore";
-import { isSuperUser } from "../lib/superUser";
+import { isSuperUser, setSuperUserKey } from "../lib/superUser";
 import type { Post } from "../types";
 import { ensureModelViewer } from "../lib/ensureModelViewer";
 
@@ -223,7 +223,8 @@ export default function PostComposer() {
   }
 
   async function handlePost() {
-    if (!isSuperUser(key)) {
+    setSuperUserKey(key);
+    if (!isSuperUser()) {
       alert("Invalid super user key");
       return;
     }

--- a/src/lib/superUser.ts
+++ b/src/lib/superUser.ts
@@ -1,4 +1,22 @@
-export const SUPER_USER_KEY = (import.meta.env.VITE_SUPER_USER_KEY || "").trim();
-export function isSuperUser(key?: string | null): boolean {
-  return !!key && key === SUPER_USER_KEY && SUPER_USER_KEY.length > 0;
+let superUserKey = "";
+
+export function setSuperUserKey(key: string) {
+  superUserKey = key.trim();
+  try {
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem("superUserKey", superUserKey);
+    }
+  } catch {
+    /* ignore */
+  }
 }
+
+export function isSuperUser(): boolean {
+  const envKey = (import.meta.env.VITE_SUPER_USER_KEY || "").trim();
+  return (
+    superUserKey.length > 0 &&
+    envKey.length > 0 &&
+    superUserKey === envKey
+  );
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,16 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import App from "./App";
+import { setSuperUserKey } from "./lib/superUser";
+
+const initialSuperKey = (() => {
+  try {
+    return localStorage.getItem("superUserKey") || "";
+  } catch {
+    return "";
+  }
+})();
+setSuperUserKey(initialSuperKey);
 
 const root = document.getElementById("root");
 if (!root) {


### PR DESCRIPTION
## Summary
- replace super user constant with mutable store and setter
- load persisted key on startup and persist on change
- ensure composer stores key before verifying

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0f4f2aa788321a5ec1ebe067aada6