### PR TITLE
Add PostComposer close controls

### DIFF
--- a/src/components/NeonRibbonComposer.tsx
+++ b/src/components/NeonRibbonComposer.tsx
@@ -90,7 +90,7 @@ export default function NeonRibbonComposer() {
           <span aria-hidden="true" className="neon-ribbon__line" />
         </div>
       )}
-      {open && <PostComposer />}
+      {open && <PostComposer onClose={closeComposer} />}
     </div>
   );
 }

--- a/src/components/PostComposer.css
+++ b/src/components/PostComposer.css
@@ -119,6 +119,16 @@
   cursor: pointer;
 }
 
+.composer__text-btn{
+  height: 36px;
+  padding: 0 12px;
+  border-radius: 10px;
+  border: 1px solid var(--stroke-2);
+  background: rgba(255,255,255,.06);
+  color: var(--ink);
+  cursor: pointer;
+}
+
 .composer__poll{
   margin-top: 10px;
   padding: 8px;

--- a/src/components/PostComposer.tsx
+++ b/src/components/PostComposer.tsx
@@ -107,7 +107,11 @@ function PollEditor({ question, options, setQuestion, setOptions, onClose }: Pol
   );
 }
 
-export default function PostComposer() {
+type PostComposerProps = {
+  onClose: () => void;
+};
+
+export default function PostComposer({ onClose }: PostComposerProps) {
   const addPost = useFeedStore((s) => s.addPost);
 
   const [text, setText] = useState("");
@@ -431,6 +435,9 @@ export default function PostComposer() {
           </button>
           <button className="composer__btn" onClick={handlePost}>
             Post
+          </button>
+          <button type="button" className="composer__text-btn" onClick={onClose}>
+            Close
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- allow PostComposer to accept an onClose callback and expose a Close button
- wire NeonRibbonComposer to forward closeComposer into PostComposer
- add frosted-glass styled .composer__text-btn

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a13cb38da88321b1dde4790ebd5513