### PR TITLE
Simplify world background gradient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/src/components/Shell.css
+++ b/src/components/Shell.css
@@ -1,18 +1,10 @@
 /* world container */
 .world-layer { position: fixed; inset: 0; z-index: 0; pointer-events: none; }
 
-/* reactive gradient background */
+/* reactive background */
 .world-bg {
-  /* default if JS hasn't run yet */
-  --tint: rgba(40, 60, 140, 0.35);
   position: absolute;
   inset: 0;
-  transition: background 300ms ease, filter 800ms ease;
-  background: radial-gradient(120% 120% at 8% 12%, var(--tint) 0%, #0f1326 52%, #070a17 100%);
-  filter: saturate(120%);
-  animation: bgShift 16s ease-in-out infinite alternate;
-}
-@keyframes bgShift{
-  0%{ filter:saturate(120%) hue-rotate(0deg); }
-  100%{ filter:saturate(140%) hue-rotate(25deg); }
+  transition: background 300ms ease;
+  background: linear-gradient(180deg, #ffffff 0%, #f0f0f0 100%);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -68,17 +68,11 @@ button, input, textarea, select { font: inherit; color: inherit; }
 
 /* Subtle reactive background */
 .world-layer { position: fixed; inset: 0; z-index: 0; pointer-events: none; }
-.world-layer canvas { pointer-events: none !important; }
+.world-layer canvas { width: 100%; height: 100%; pointer-events: none !important; }
 .world-bg {
   position: absolute; inset: 0;
-  transition: background 600ms ease, filter 800ms ease;
-  background: radial-gradient(120% 120% at 8% 12%, rgba(40,60,140,.35) 0%, #0f1326 52%, #070a17 100%);
-  filter: saturate(120%);
-  animation: bgShift 16s ease-in-out infinite alternate;
-}
-@keyframes bgShift {
-  0% { filter: saturate(120%) hue-rotate(0deg); }
-  100% { filter: saturate(140%) hue-rotate(25deg); }
+  transition: background 600ms ease;
+  background: linear-gradient(180deg, #ffffff 0%, #f0f0f0 100%);
 }
 
 /* =========================


### PR DESCRIPTION
## Summary
- Replace animated blue world background with a static white-to-gray gradient
- Remove saturation and hue-shift filters from world background styles
- Ensure world canvas fills viewport and stays non-interactive; add `.gitignore`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a13c37578083219f7c11247e2a041e