### PR TITLE
Lock theme to light and colorize background orbs

### DIFF
--- a/src/lib/world.ts
+++ b/src/lib/world.ts
@@ -1,6 +1,6 @@
 // src/lib/world.ts
 export type WorldState = {
-  theme: "light" | "dark";
+  theme: "light";
   orbCount: number;       // 1..64
   orbColor: string;       // css color or #hex
   gridOpacity: number;    // 0..1
@@ -10,18 +10,18 @@ export type WorldState = {
 export const defaultWorld: WorldState = {
   theme: "light",
   orbCount: 14,
-  orbColor: "#67e8f9", // teal/cyan instead of purple
-  gridOpacity: 0.18,
-  fogLevel: 0.5,
+  orbColor: "#ffffff",
+  gridOpacity: 0.05,
+  fogLevel: 0.02,
 };
 
 // small clamps so bad input never explodes
 export function clampWorld(s: WorldState): WorldState {
   const clamp = (n: number, a: number, b: number) => Math.min(b, Math.max(a, n));
   return {
-    theme: s.theme === "dark" ? "dark" : "light",
+    theme: "light",
     orbCount: Math.round(clamp(s.orbCount, 1, 64)),
-    orbColor: s.orbColor || "#67e8f9",
+    orbColor: s.orbColor || "#ffffff",
     gridOpacity: clamp(s.gridOpacity, 0, 1),
     fogLevel: clamp(s.fogLevel, 0, 1),
   };

--- a/src/three/BackgroundVoid.tsx
+++ b/src/three/BackgroundVoid.tsx
@@ -35,13 +35,27 @@ export default function BackgroundVoid() {
     });
   }, []);
 
-  const bg = w.theme === "dark" ? "#0b0d12" : "#f6f8fb";
-  const fogC = w.theme === "dark" ? "#0b0d12" : "#f1f4fa";
-  const gridC = w.theme === "dark" ? "#283044" : "#e5eaf4";
+  const bg = "#f6f8fb";
+  const fogC = "#f1f4fa";
+  const gridC = "#e5eaf4";
   const fogNear = 12 + w.fogLevel * 6;
   const fogFar = 44 - w.fogLevel * 16;
 
   const positions = useMemo(() => ringPositions(w.orbCount), [w.orbCount]);
+  const orbColors = useMemo(
+    () => [
+      "#f87171",
+      "#fb923c",
+      "#fbbf24",
+      "#a3e635",
+      "#4ade80",
+      "#2dd4bf",
+      "#38bdf8",
+      "#818cf8",
+      "#e879f9",
+    ],
+    []
+  );
 
   return (
     <div style={{ position: "fixed", inset: 0, zIndex: 0, pointerEvents: "none" }}>
@@ -55,8 +69,9 @@ export default function BackgroundVoid() {
           <Instances limit={64}>
             <sphereGeometry args={[0.26, 32, 32]} />
             <meshStandardMaterial
+              vertexColors
               color={w.orbColor}
-              emissive={w.theme === "dark" ? "#6b72ff" : "#b6bcff"}
+              emissive="#b6bcff"
               emissiveIntensity={0.16}
               roughness={0.25}
               metalness={0.55}
@@ -68,7 +83,7 @@ export default function BackgroundVoid() {
                 rotationIntensity={0.25}
                 speed={0.9 + (i % 4) * 0.15}
               >
-                <Instance position={p} />
+                <Instance position={p} color={orbColors[i % orbColors.length]} />
               </Float>
             ))}
           </Instances>


### PR DESCRIPTION
## Summary
- Fix world theme to always use light mode with minimal fog and grid opacity
- Render orbs in vibrant per-instance colors against a bright scene

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a13c4dff048321be93d43b4371948f