### PR TITLE
Increase MenuOrb z-index to remain clickable over sidebar

### DIFF
--- a/src/components/MenuOrb.test.tsx
+++ b/src/components/MenuOrb.test.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import MenuOrb from "./MenuOrb";
+import bus from "../lib/bus";
+
+describe("MenuOrb interactions", () => {
+  it("emits sidebar toggle even when sidebar is open", () => {
+    const emitSpy = vi.spyOn(bus, "emit");
+    const { getByRole } = render(
+      <>
+        <div className="sb open" />
+        <MenuOrb />
+      </>
+    );
+    const orb = getByRole("button", { name: /toggle sidebar/i });
+    fireEvent.click(orb);
+    expect(emitSpy).toHaveBeenCalledWith("sidebar:toggle");
+    emitSpy.mockRestore();
+  });
+
+  it("sets a z-index above the sidebar", () => {
+    const { container } = render(<MenuOrb />);
+    const styleTag = container.querySelector("style");
+    expect(styleTag?.textContent).toContain("z-index:80");
+  });
+});

--- a/src/components/MenuOrb.tsx
+++ b/src/components/MenuOrb.tsx
@@ -25,7 +25,7 @@ export default function MenuOrb() {
       </div>
       <style>{`
         .menu-orb{
-          position:fixed;left:16px;top:16px;z-index:60;
+          position:fixed;left:16px;top:16px;z-index:80;
           width:64px;height:64px;cursor:pointer;
         }
         .menu-orb .orb-core{


### PR DESCRIPTION
## Summary
- elevate `MenuOrb` above the sidebar with `z-index:80`
- test that the orb still toggles the sidebar when it is open
- verify styling includes higher z-index

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a16ec7572083219266ad16b037ec3f