### PR TITLE
Refactor sentinel observation in infinite scroll hook

### DIFF
--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -65,13 +65,21 @@ export function useInfiniteScroll<T>(opts: {
       }
     }, { rootMargin });
     observerRef.current = io;
-    const node = sentinelRef.current;
-    if (node) io.observe(node);
     return () => {
       cancelled = true;
       observerRef.current?.disconnect();
     };
-  }, [loadMore, hasMore, rootMargin, sentinelRef.current]);
+  }, [loadMore, hasMore, rootMargin]);
+
+  useEffect(() => {
+    const node = sentinelRef.current;
+    const observer = observerRef.current;
+    if (!node || !observer) return;
+    observer.observe(node);
+    return () => {
+      observer.unobserve(node);
+    };
+  }, [sentinelRef.current, observerRef.current]);
 
   return { items, setItems, page, setPage, loading, error, sentinelRef };
 }


### PR DESCRIPTION
## Summary
- stop recreating IntersectionObserver when the sentinel ref changes
- watch the sentinel node separately and (un)observe on ref changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a16f68c69883218ef935e7e17c48f3