### PR TITLE
fix: refine legacy clipboard fallback

### DIFF
--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -60,21 +60,33 @@ export async function sharePost(arg: Post | ShareOptions | string): Promise<bool
   }
 
   // Legacy execCommand fallback
+  // TODO: Remove once navigator.clipboard has broader support.
   if (typeof document === "undefined") return false;
 
   const ta = document.createElement("textarea");
   try {
+    if (!document.body) {
+      console.error("sharePost: document.body is not available");
+      return false;
+    }
+
     ta.value = url;
     ta.style.position = "fixed";
     ta.style.opacity = "0";
     document.body.appendChild(ta);
     ta.select();
-    document.execCommand("copy");
-    return true;
-  } catch {
+    const success = document.execCommand("copy");
+    if (!success) {
+      console.error("sharePost: copy command failed");
+    }
+    return success;
+  } catch (err) {
+    console.error("sharePost: unable to copy", err);
     return false;
   } finally {
-    document.body.removeChild(ta);
+    if (document.body && ta.parentNode === document.body) {
+      document.body.removeChild(ta);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure `document.body` exists before using it in `sharePost`
- return success flag from `execCommand("copy")` and log copy failures
- note TODO for removing deprecated `execCommand` path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a16f55e6a48321b1a829e582f9cc83