### PR TITLE
Render shared links below post media

### DIFF
--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -154,6 +154,16 @@ export default function PostCard({ post }: { post: Post }) {
             <AmbientWorld className="pc-media" />
           )}
         </div>
+        {post.link && (
+          <a
+            className="pc-link"
+            href={post.link}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {post.link}
+          </a>
+        )}
 
         <div className="pc-botbar" role="toolbar" aria-label="Post actions">
           <div className="pc-ava"

--- a/src/components/feed/PostCard.tsx
+++ b/src/components/feed/PostCard.tsx
@@ -201,6 +201,17 @@ export default function PostCard({ post }: { post: Post }) {
           )}
         </div>
 
+        {post.link && (
+          <a
+            className="pc-link"
+            href={post.link}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {post.link}
+          </a>
+        )}
+
         {pollOpts.length > 0 && (
           <div className="pc-poll">
             {!voted

--- a/src/components/feed/postcard.css
+++ b/src/components/feed/postcard.css
@@ -80,6 +80,15 @@
   max-height: 80vh;
 }
 
+.pc-link{
+  display:block;
+  margin:6px 0;
+  color:var(--pc-muted);
+  text-decoration:underline;
+  overflow-wrap:anywhere;
+  word-break:break-all;
+}
+
 /* carousel (for multiple images) */
 .pc-carousel{
   display:grid; grid-auto-flow:column; grid-auto-columns:100%;

--- a/src/components/postcard.css
+++ b/src/components/postcard.css
@@ -46,6 +46,15 @@
 
 .pc-media-wrap{ margin:0; }
 
+.pc-link{
+  display:block;
+  margin:6px 0;
+  color:var(--pc-muted);
+  text-decoration:underline;
+  overflow-wrap:anywhere;
+  word-break:break-all;
+}
+
 .pc-media{
   display:block; width:100%; height:auto; aspect-ratio:4/5;
   object-fit:cover; background:#0f1117; border-radius:8px;


### PR DESCRIPTION
## Summary
- Display `post.link` under media in PostCard and feed cards
- Add `.pc-link` style for muted, underlined external links with safe wrapping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a17275ac408321940966224d7306ab