### PR TITLE
fix: keep post reactions from wrapping

### DIFF
--- a/src/components/feed/postcard.css
+++ b/src/components/feed/postcard.css
@@ -177,9 +177,15 @@
   margin-top:8px;
   display:flex;
   gap:6px;
-  flex-wrap:wrap;
+  flex-wrap:nowrap;
   color: var(--pc-ink);
+  overflow-x:auto;
+  overflow-y:auto;
+  max-height:120px;
+  -webkit-overflow-scrolling:touch;
+  scrollbar-width:none;
 }
+.pc-reactions::-webkit-scrollbar{ display:none; }
 .pc-emo-count{
   font-size:14px;
   background: rgba(255,255,255,.06);

--- a/src/components/postcard.css
+++ b/src/components/postcard.css
@@ -124,6 +124,7 @@
 .pc-emoji{ height:var(--pc-emoji-size); min-width:var(--pc-emoji-size); padding:0 6px; border-radius:999px; display:grid; place-items:center; font-size:18px; cursor:pointer; background: rgba(255,255,255,.06); border:1px solid rgba(255,255,255,.12); max-width:100%; box-sizing:border-box; }
 .pc-section{ margin-top:12px; }
 .pc-reactions{
+  /* horizontally scroll reaction chips without wrapping */
   display:flex;
   flex-wrap:nowrap;
   gap:6px;


### PR DESCRIPTION
## Summary
- limit PostCard reaction lists to a horizontal scroll and hide their scrollbar
- mirror reaction overflow styling in feed/PostCard for layout consistency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1f393053c8321ab1a7b2405caef0c