### PR TITLE
Enable scrolling for reactions without wrapping

### DIFF
--- a/src/components/feed/postcard.css
+++ b/src/components/feed/postcard.css
@@ -177,8 +177,15 @@
   margin-top:8px;
   display:flex;
   gap:6px;
-  flex-wrap:wrap;
+  flex-wrap:nowrap;
+  overflow-x:auto;
+  overflow-y:auto;
+  max-height:120px;
   color: var(--pc-ink);
+  scrollbar-width:none;
+}
+.pc-reactions::-webkit-scrollbar{
+  display:none;
 }
 .pc-emo-count{
   font-size:14px;


### PR DESCRIPTION
## Summary
- Prevent post card reactions from wrapping and enable scrolling
- Hide scrollbars and limit reaction section height

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a20ca1159c8321bba14b27d946fe51