### PR TITLE
feat: scroll reactions

### DIFF
--- a/src/components/feed/PostCard.test.tsx
+++ b/src/components/feed/PostCard.test.tsx
@@ -1,9 +1,12 @@
 // src/components/feed/PostCard.test.tsx
 import React from "react";
-import { render, fireEvent } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import PostCard from "./PostCard";
 import type { Post } from "../../types";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
 
 describe("PostCard image grid", () => {
   const post: Post = {
@@ -18,6 +21,30 @@ describe("PostCard image grid", () => {
     const imgs = Array.from(gallery.querySelectorAll("img")) as HTMLImageElement[];
     expect(imgs.length).toBe(3);
     expect(imgs[0].getAttribute("src")).toBe("/a.jpg");
+  });
+});
+
+describe("PostCard reactions scrolling", () => {
+  it("scrolls lengthy reaction sets", () => {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = path.dirname(__filename);
+    const css = fs.readFileSync(path.join(__dirname, "./postcard.css"), "utf8");
+    const styleEl = document.createElement("style");
+    styleEl.innerHTML = css;
+    document.head.appendChild(styleEl);
+    const wrap = document.createElement("div");
+    wrap.className = "pc-reactions";
+    for (let i = 0; i < 50; i++) {
+      const span = document.createElement("span");
+      span.className = "pc-emo-count";
+      span.textContent = "🔥";
+      wrap.appendChild(span);
+    }
+    document.body.appendChild(wrap);
+    const style = getComputedStyle(wrap);
+    expect(style.overflowY).toBe("auto");
+    expect(style.overflowX).toBe("auto");
+    expect(style.maxHeight).toBe("120px");
   });
 });
 

--- a/src/components/feed/postcard.css
+++ b/src/components/feed/postcard.css
@@ -174,12 +174,17 @@
 }
 
 .pc-reactions{
-  margin-top:8px;
   display:flex;
+  flex-wrap:nowrap;
   gap:6px;
-  flex-wrap:wrap;
-  color: var(--pc-ink);
+  margin-top:8px;
+  overflow-x:auto;
+  overflow-y:auto;
+  max-height:120px;
+  -webkit-overflow-scrolling:touch;
+  scrollbar-width:none;
 }
+.pc-reactions::-webkit-scrollbar{ display:none; }
 .pc-emo-count{
   font-size:14px;
   background: rgba(255,255,255,.06);


### PR DESCRIPTION
## Summary
- allow reaction sets in feed to scroll horizontally and vertically without wrapping
- hide reaction scrollbars for a cleaner feed
- test overflow styling of reaction blocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a20c98f5a48321982ff698373cbec7