### PR TITLE
feat: secure in-memory key storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Fetching images from Unsplash or Pexels requires API keys. Set the following var
 - `VITE_UNSPLASH_KEY` – Unsplash access key
 - `VITE_PEXELS_KEY` – Pexels API key
 
-The app reads these values from `import.meta.env` and falls back to any keys stored in `localStorage.sn.keys` for local testing.
+The app reads these values from `import.meta.env` and falls back to any keys stored in the in-memory secure store for local testing.
 
 ### Adding keys on Vercel
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,6 +3,11 @@ import { NavLink } from "react-router-dom";
 import "./Sidebar.css";
 import bus from "../lib/bus";
 import { useTheme } from "../lib/useTheme";
+import {
+  getKey as getSecureKey,
+  setKey as setSecureKey,
+  removeKey as removeSecureKey,
+} from "../lib/secureStore";
 
 function useLocal<T>(key: string, init: T) {
   const [v, setV] = useState<T>(() => {
@@ -21,6 +26,19 @@ function useLocal<T>(key: string, init: T) {
     } catch {}
   }, [key, v]);
   return [v, setV] as const;
+}
+
+function useSecure(key: string) {
+  const [v, setV] = useState(() =>
+    typeof window === "undefined" ? "" : getSecureKey(key),
+  );
+  const update = (val: string) => {
+    setV(val);
+    if (typeof window === "undefined") return;
+    if (val) setSecureKey(key, val);
+    else removeSecureKey(key);
+  };
+  return [v, update] as const;
 }
 
 export default function Sidebar() {
@@ -68,12 +86,9 @@ export default function Sidebar() {
     document.documentElement.style.setProperty("--accent", accent);
   }, [accent]);
 
-  const [openaiKey, setOpenaiKey] = useLocal("sn.keys.openai", "");
-  const [anthropicKey, setAnthropicKey] = useLocal("sn.keys.anthropic", "");
-  const [perplexityKey, setPerplexityKey] = useLocal(
-    "sn.keys.perplexity",
-    "",
-  );
+  const [openaiKey, setOpenaiKey] = useSecure("openai");
+  const [anthropicKey, setAnthropicKey] = useSecure("anthropic");
+  const [perplexityKey, setPerplexityKey] = useSecure("perplexity");
   const [openaiDraft, setOpenaiDraft] = useState(openaiKey);
   const [anthropicDraft, setAnthropicDraft] = useState(anthropicKey);
   const [perplexityDraft, setPerplexityDraft] = useState(perplexityKey);
@@ -95,9 +110,6 @@ export default function Sidebar() {
       onClear: () => {
         setOpenaiDraft("");
         setOpenaiKey("");
-        if (typeof window !== "undefined") {
-          setTimeout(() => window.localStorage.removeItem("sn.keys.openai"), 0);
-        }
       },
     },
     {
@@ -109,12 +121,6 @@ export default function Sidebar() {
       onClear: () => {
         setAnthropicDraft("");
         setAnthropicKey("");
-        if (typeof window !== "undefined") {
-          setTimeout(
-            () => window.localStorage.removeItem("sn.keys.anthropic"),
-            0,
-          );
-        }
       },
     },
     {
@@ -126,12 +132,6 @@ export default function Sidebar() {
       onClear: () => {
         setPerplexityDraft("");
         setPerplexityKey("");
-        if (typeof window !== "undefined") {
-          setTimeout(
-            () => window.localStorage.removeItem("sn.keys.perplexity"),
-            0,
-          );
-        }
       },
     },
   ];

--- a/src/components/feed/InfiniteFeed.tsx
+++ b/src/components/feed/InfiniteFeed.tsx
@@ -9,7 +9,7 @@ import SkeletonCard from "./SkeletonCard";
 /**
  * InfiniteFeed
  * - True infinite scroll via IntersectionObserver
- * - Default provider: Picsum (no key). If you add localStorage.sn.keys.unsplash or .pexels, set provider prop.
+ * - Default provider: Picsum (no key). If you add secure-store keys for Unsplash or Pexels, set provider prop.
  * - Compatible with your Orb: each card has data-post-id and .pc-media img for tint.
  */
 export default function InfiniteFeed({

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,5 @@
 // src/lib/api.ts
+import { getKey } from "./secureStore";
 
 interface AssistantReplyJson {
   ok: boolean;
@@ -21,14 +22,7 @@ interface PlayersJson {
 export async function assistantReply(
   prompt: string,
 ): Promise<{ ok: boolean; text?: string; error?: string }> {
-  let apiKey = "";
-  if (typeof window !== "undefined") {
-    try {
-      apiKey = localStorage.getItem("sn2177.apiKey") || "";
-    } catch {
-      apiKey = "";
-    }
-  }
+  const apiKey = getKey("sn2177.apiKey");
   try {
     const r = await fetch("/api/assistant-reply", {
       method: "POST",

--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -1,5 +1,6 @@
 // src/lib/assistant.ts
 import type { AssistantMessage, RemixSpec } from "../types";
+import { getKey } from "./secureStore";
 
 type AssistantCtx = {
   postId?: string | number;
@@ -83,14 +84,7 @@ export async function askLLMVoice(
   prompt: string,
   ctx?: AssistantCtx,
 ): Promise<ReadableStream<Uint8Array> | null> {
-  let apiKey = "";
-  if (typeof window !== "undefined") {
-    try {
-      apiKey = window.localStorage.getItem("sn2177.apiKey") || "";
-    } catch {
-      apiKey = "";
-    }
-  }
+  const apiKey = getKey("sn2177.apiKey");
 
   try {
     const payload: Record<string, unknown> = { apiKey, prompt };

--- a/src/lib/imageProviders.test.ts
+++ b/src/lib/imageProviders.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fetchImages } from "./imageProviders";
+import { clearAll } from "./secureStore";
 
 describe("fetchImages", () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    window.localStorage.clear();
+    clearAll();
   });
 
   it("warns once and falls back to picsum when API key is missing", async () => {

--- a/src/lib/imageProviders.ts
+++ b/src/lib/imageProviders.ts
@@ -1,3 +1,5 @@
+import { getKey as getStoredKey } from "./secureStore";
+
 export type FeedImage = {
   id: string;
   src: string;         // display src (optimized for width ~1200)
@@ -18,8 +20,8 @@ type FetchArgs = {
 };
 
 /**
- * Read API keys from Vite env first, then fall back to localStorage
- * (so you don’t need env vars to test)
+ * Read API keys from Vite env first, then fall back to the in-memory
+ * secure store (so you don’t need env vars to test)
  */
 function getKey(name: string) {
   const envMap: Record<string, string | undefined> = {
@@ -28,10 +30,8 @@ function getKey(name: string) {
   };
   const envKey = envMap[name];
   if (envKey) return envKey;
-  if (typeof window !== "undefined" && window.localStorage) {
-    try { return JSON.parse(window.localStorage.getItem("sn.keys") || "{}")[name]; } catch { return undefined; }
-  }
-  return undefined;
+  const k = getStoredKey(name);
+  return k || undefined;
 }
 
 const warnedProviders = new Set<string>();
@@ -68,7 +68,7 @@ async function fetchPicsum(page: number, perPage: number): Promise<FeedImage[]> 
   });
 }
 
-/** UNSPLASH (optional) — needs access key (store as localStorage.sn.keys.unsplash) */
+/** UNSPLASH (optional) — needs access key (use secureStore key "unsplash") */
 async function fetchUnsplash(page: number, perPage: number, query?: string): Promise<FeedImage[]> {
   const key = getKey("unsplash");
   if (!key) {
@@ -101,7 +101,7 @@ async function fetchUnsplash(page: number, perPage: number, query?: string): Pro
   } as FeedImage));
 }
 
-/** PEXELS (optional) — needs key (store as localStorage.sn.keys.pexels) */
+/** PEXELS (optional) — needs key (use secureStore key "pexels") */
 async function fetchPexels(page: number, perPage: number, query?: string): Promise<FeedImage[]> {
   const key = getKey("pexels");
   if (!key) {

--- a/src/lib/secureStore.ts
+++ b/src/lib/secureStore.ts
@@ -1,0 +1,17 @@
+const store: Record<string, string> = {};
+
+export function getKey(name: string): string {
+  return store[name] || "";
+}
+
+export function setKey(name: string, value: string): void {
+  store[name] = value;
+}
+
+export function removeKey(name: string): void {
+  delete store[name];
+}
+
+export function clearAll(): void {
+  for (const k of Object.keys(store)) delete store[k];
+}

--- a/src/lib/superUser.ts
+++ b/src/lib/superUser.ts
@@ -1,47 +1,27 @@
 // superUser.ts
 // Unified helpers for setting/getting/checking a Super User key.
-// - Persists to localStorage under one stable key
-// - Keeps an in-memory cache
+// - Uses in-memory secure storage (no localStorage persistence)
 // - Prefers env VITE_SUPER_USER_KEY when configured; otherwise falls back to a non-empty stored key (dev use)
 
 export const STORAGE_KEY = "12345";
 
-let superUserKeyMem = "";
+import { getKey, setKey, removeKey } from "./secureStore";
 
-/** Safely read from localStorage (SSRed/blocked environments safe). */
-function readStored(): string {
-  if (typeof localStorage === "undefined") return "";
-  try {
-    return localStorage.getItem(STORAGE_KEY)?.trim() || "";
-  } catch {
-    return "";
-  }
-}
-
-/** Current key (memory first, then storage). */
+/** Current key. */
 export function getSuperUserKey(): string {
-  if (superUserKeyMem) return superUserKeyMem;
-  superUserKeyMem = readStored();
-  return superUserKeyMem;
+  return getKey(STORAGE_KEY);
 }
 
-/** Set & persist the key (empty string clears storage). */
+/** Set the key (empty string clears storage). */
 export function setSuperUserKey(key: string) {
   const k = (key ?? "").trim();
-  superUserKeyMem = k;
-  if (typeof localStorage !== "undefined") {
-    try {
-      if (k) localStorage.setItem(STORAGE_KEY, k);
-      else localStorage.removeItem(STORAGE_KEY);
-    } catch {
-      /* ignore */
-    }
-  }
+  if (k) setKey(STORAGE_KEY, k);
+  else removeKey(STORAGE_KEY);
 }
 
 /** Optional convenience to clear the key explicitly. */
 export function clearSuperUserKey() {
-  setSuperUserKey("");
+  removeKey(STORAGE_KEY);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add in-memory secure store for sensitive keys
- Update settings sidebar and API helpers to use secure storage
- Refresh docs and comments to mention new mechanism

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a21583d9c08321ac16f2d274e3e92b