### PR TITLE
Handle missing API key gracefully

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -18,6 +18,19 @@ interface PlayersJson {
   error?: string;
 }
 
+let missingKeyNoticeShown = false;
+function notifyMissingKey() {
+  if (missingKeyNoticeShown) return;
+  missingKeyNoticeShown = true;
+  if (typeof window !== "undefined") {
+    try {
+      window.alert?.("Missing API key. Configure sn2177.apiKey in localStorage.");
+    } catch {
+      // ignore
+    }
+  }
+}
+
 export async function assistantReply(
   prompt: string,
 ): Promise<{ ok: boolean; text?: string; error?: string }> {
@@ -28,6 +41,10 @@ export async function assistantReply(
     } catch {
       apiKey = "";
     }
+  }
+  if (!apiKey) {
+    notifyMissingKey();
+    return { ok: true, text: `💡 stub: “${prompt}”` };
   }
   try {
     const r = await fetch("/api/assistant-reply", {

--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -7,6 +7,19 @@ type AssistantCtx = {
   text?: string;
 } | null;
 
+let voiceKeyNoticeShown = false;
+function notifyVoiceKey() {
+  if (voiceKeyNoticeShown) return;
+  voiceKeyNoticeShown = true;
+  if (typeof window !== "undefined") {
+    try {
+      window.alert?.("Missing API key. Configure sn2177.apiKey in localStorage.");
+    } catch {
+      // ignore
+    }
+  }
+}
+
 export async function askLLM(
   input: string,
   ctx?: AssistantCtx,
@@ -90,6 +103,11 @@ export async function askLLMVoice(
     } catch {
       apiKey = "";
     }
+  }
+
+  if (!apiKey) {
+    notifyVoiceKey();
+    return null;
   }
 
   try {


### PR DESCRIPTION
## Summary
- Show one-time alert when `sn2177.apiKey` is missing
- Skip network calls and return stub replies when the key is absent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a215821f448321a307cc5de1c48b9b