### PR TITLE
Use global randomUUID fallback in assistant

### DIFF
--- a/src/lib/assistant.test.ts
+++ b/src/lib/assistant.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { askLLM } from "./assistant";
+
+describe("askLLM id generation", () => {
+  const originalFetch = global.fetch;
+  const originalCryptoDesc = Object.getOwnPropertyDescriptor(global, "crypto");
+  const originalRandom = Math.random;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    if (originalCryptoDesc) {
+      Object.defineProperty(global, "crypto", originalCryptoDesc);
+    } else {
+      // @ts-ignore
+      delete global.crypto;
+    }
+    Math.random = originalRandom;
+    vi.resetAllMocks();
+  });
+
+  it("uses crypto.randomUUID when available", async () => {
+    const mockFetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ text: "hi" }),
+    })) as any;
+    // @ts-ignore
+    global.fetch = mockFetch;
+    const uuid = "uuid-123";
+    Object.defineProperty(global, "crypto", {
+      value: { randomUUID: () => uuid },
+      configurable: true,
+    });
+
+    const msg = await askLLM("hello");
+    expect(msg.id).toBe(uuid);
+  });
+
+  it("falls back to Math.random when crypto.randomUUID is unavailable", async () => {
+    const mockFetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ text: "hi" }),
+    })) as any;
+    // @ts-ignore
+    global.fetch = mockFetch;
+    // @ts-ignore
+    delete global.crypto;
+    Math.random = () => 0.123456789;
+
+    const msg = await askLLM("hello");
+    expect(msg.id).toBe("4fzzzxjylrx");
+  });
+});

--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -42,7 +42,9 @@ export async function askLLM(
     if (res.ok) {
       const data = await res.json();
       return {
-        id: crypto.randomUUID(),
+        id:
+          globalThis.crypto?.randomUUID?.() ??
+          Math.random().toString(36).slice(2),
         role: "assistant",
         text: data.text || "ok",
         ts: Date.now(),
@@ -71,7 +73,9 @@ export async function askLLM(
 
   // offline stub so builds never fail
   return {
-    id: crypto.randomUUID(),
+    id:
+      globalThis.crypto?.randomUUID?.() ??
+      Math.random().toString(36).slice(2),
     role: "assistant",
     text: `💡 stub: “${input}”`,
     ts: Date.now(),


### PR DESCRIPTION
## Summary
- use `globalThis.crypto?.randomUUID?.()` with a `Math.random` fallback when generating assistant IDs
- cover UUID generation paths in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2157e0fc48321a423012604d50cec