### PR TITLE
Throttle alerts and display toast notifications

### DIFF
--- a/src/components/PostComposer.tsx
+++ b/src/components/PostComposer.tsx
@@ -8,6 +8,7 @@ import {
 } from "../lib/superUser";
 import type { Post } from "../types";
 import { ensureModelViewer } from "../lib/ensureModelViewer";
+import { notify } from "../lib/notify";
 
 type PollEditorProps = {
   question: string;
@@ -44,7 +45,7 @@ function PollEditor({ question, options, setQuestion, setOptions, onClose }: Pol
     const q = question.trim();
     const opts = options.map((o) => o.trim()).filter(Boolean);
     if (!q || opts.length < 2) {
-      alert("Please enter a question and at least two options");
+      notify("Please enter a question and at least two options");
       return;
     }
     onClose();
@@ -237,7 +238,7 @@ export default function PostComposer({ onClose }: PostComposerProps) {
   async function handlePost() {
     setSuperUserKey(key);
     if (!isSuperUser()) {
-      alert("Invalid super user key");
+      notify("Invalid super user key");
       return;
     }
     const hasText = text.trim().length > 0;

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -9,6 +9,7 @@ import Sidebar from "./Sidebar";
 import PortalOverlay from "./PortalOverlay";
 import NeonRibbonComposer from "./NeonRibbonComposer";
 import AvatarPortal from "./AvatarPortal";
+import ToastContainer from "./ToastContainer";
 
 export default function Shell() {
   return (
@@ -29,6 +30,7 @@ export default function Shell() {
       <ChatDock />
       <AssistantOrb />
       <AvatarPortal />
+      <ToastContainer />
     </>
   );
 }

--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+import Toast from "./Toast";
+import { on } from "../lib/bus";
+
+export default function ToastContainer() {
+  const [msg, setMsg] = useState("");
+
+  useEffect(() => {
+    const off = on("notify", (m: string) => setMsg(m));
+    return off;
+  }, []);
+
+  useEffect(() => {
+    if (!msg) return;
+    const t = setTimeout(() => setMsg(""), 3000);
+    return () => clearTimeout(t);
+  }, [msg]);
+
+  if (!msg) return null;
+  return <Toast message={msg} onClose={() => setMsg("")} />;
+}

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -1,0 +1,10 @@
+import { emit } from "./bus";
+
+let last = 0;
+
+export function notify(message: string) {
+  const now = Date.now();
+  if (now - last < 60_000) return;
+  last = now;
+  emit("notify", message);
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -344,3 +344,22 @@ button, input, textarea, select { font: inherit; color: inherit; }
   transition: clip-path .65s cubic-bezier(.22,.61,.36,1), opacity .2s ease;
 }
 .portal-overlay.on { --r0: 160vmax; opacity: 1; }
+
+/* generic toast overlay */
+.toast-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 1000;
+}
+
+.toast {
+  background: #fff;
+  padding: 16px 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+  max-width: 90%;
+}


### PR DESCRIPTION
## Summary
- Introduce `notify` utility to throttle notifications to at most one per minute
- Replace direct `alert` calls in `PostComposer` with new `notify` toast messages
- Add `ToastContainer` and global styles for simple on-screen notifications

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a21574f0448321b6e3f4d037c825e6