### PR TITLE
Use share helper and toast feedback for copying post links

### DIFF
--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef, useState } from "react";
 import bus from "../lib/bus";
 import { logError } from "../lib/logger";
 import { askLLM, askLLMVoice } from "../lib/assistant";
+import sharePost from "../lib/share";
 import type { AssistantMessage, Post } from "../types";
 import RadialMenu from "./RadialMenu";
 import { HOLD_MS } from "./orbConstants";
@@ -870,7 +871,9 @@ export default function AssistantOrb() {
                 onClick={async () => {
                   if (!ctxPost) return;
                   const url = `${location.origin}${location.pathname}#post-${ctxPost.id}`;
-                  try { await navigator.clipboard.writeText(url); setToast("Link copied"); setTimeout(() => setToast(""), 900); } catch {}
+                  const ok = await sharePost(url);
+                  setToast(ok ? "Link copied" : "Copy failed");
+                  setTimeout(() => setToast(""), 900);
                   setPetal(null);
                 }}
               >

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import "./postcard.css";
 import type { Post } from "../types";
 import bus from "../lib/bus";
+import sharePost from "../lib/share";
 import { ensureModelViewer } from "../lib/ensureModelViewer";
 import AmbientWorld from "./AmbientWorld";
 
@@ -191,13 +192,19 @@ export default function PostCard({ post }: { post: Post }) {
                       fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round"/>
               </svg>
             </button>
-            <button className="pc-act" aria-label="Share" title="Share"
+            <button
+              className="pc-act"
+              aria-label="Share"
+              title="Share"
               onClick={async () => {
-                if (typeof location !== "undefined" && typeof navigator !== "undefined" && (navigator as any).clipboard?.writeText) {
-                  const url = `${location.origin}${location.pathname}#post-${post.id}`;
-                  try { await (navigator as any).clipboard.writeText(url); } catch {}
-                }
-              }}>
+                const url =
+                  typeof location !== "undefined"
+                    ? `${location.origin}${location.pathname}#post-${post.id}`
+                    : "";
+                const ok = await sharePost(url);
+                bus.emit?.("toast", ok ? "Link copied" : "Copy failed");
+              }}
+            >
               <svg className="ico" viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M14 9V5l7 7-7 7v-4H4V9h10Z"
                       fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round"/>

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -1,5 +1,5 @@
 // src/components/Shell.tsx
-import React from "react";
+import React, { useEffect, useState } from "react";
 import Feed from "./feed/Feed";
 import World3D from "./World3D";
 import AssistantOrb from "./AssistantOrb";
@@ -9,8 +9,20 @@ import Sidebar from "./Sidebar";
 import PortalOverlay from "./PortalOverlay";
 import NeonRibbonComposer from "./NeonRibbonComposer";
 import AvatarPortal from "./AvatarPortal";
+import Toast from "./Toast";
+import bus from "../lib/bus";
 
 export default function Shell() {
+  const [toast, setToast] = useState("");
+
+  useEffect(() => {
+    const off = bus.on("toast", (msg: string) => {
+      setToast(msg);
+      window.setTimeout(() => setToast(""), 1500);
+    });
+    return off;
+  }, []);
+
   return (
     <>
       {/* 3D world behind everything */}
@@ -29,6 +41,7 @@ export default function Shell() {
       <ChatDock />
       <AssistantOrb />
       <AvatarPortal />
+      {toast && <Toast message={toast} onClose={() => setToast("")} />}
     </>
   );
 }

--- a/src/components/feed/PostCard.tsx
+++ b/src/components/feed/PostCard.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import "./postcard.css";
 import type { Post } from "../../types";
 import bus from "../../lib/bus";
+import sharePost from "../../lib/share";
 import { ensureModelViewer } from "../../lib/ensureModelViewer";
 import AmbientWorld from "../AmbientWorld";
 
@@ -107,11 +108,14 @@ export default function PostCard({ post }: { post: Post }) {
     if (src.startsWith("blob:")) try { URL.revokeObjectURL(src); } catch {}
   };
 
-  // share link (preserve old behavior)
+  // share link
   async function copyLink() {
-    if (typeof location === "undefined" || typeof navigator === "undefined") return;
-    const url = `${location.origin}${location.pathname}#post-${post.id}`;
-    try { await navigator.clipboard.writeText(url); } catch {}
+    const url =
+      typeof location !== "undefined"
+        ? `${location.origin}${location.pathname}#post-${post.id}`
+        : "";
+    const ok = await sharePost(url);
+    bus.emit?.("toast", ok ? "Link copied" : "Copy failed");
   }
 
   const handleVote = (optId: string, index: number) => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -344,3 +344,33 @@ button, input, textarea, select { font: inherit; color: inherit; }
   transition: clip-path .65s cubic-bezier(.22,.61,.36,1), opacity .2s ease;
 }
 .portal-overlay.on { --r0: 160vmax; opacity: 1; }
+
+/* =========================
+   Global Toast
+   ========================= */
+.toast-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 10000;
+}
+
+.toast {
+  background: rgba(0,0,0,.75);
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0,0,0,.3);
+  pointer-events: auto;
+}
+
+.toast button {
+  margin-left: 12px;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- replace inline clipboard usage in post cards and assistant orb with `sharePost`
- broadcast share results via global toast host
- add basic toast styles for user feedback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2155b35ec83219ced9377019267e7