### PR TITLE
Aggregate post reactions with counts

### DIFF
--- a/src/components/PostCard.test.tsx
+++ b/src/components/PostCard.test.tsx
@@ -1,11 +1,23 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, act } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import PostCard from "./PostCard";
 
-vi.mock("../lib/bus", () => ({
-  default: { on: () => () => {}, emit: () => {} }
-}));
+vi.mock("../lib/bus", () => {
+  const listeners: Record<string, any[]> = {};
+  return {
+    default: {
+      on: (event: string, cb: any) => {
+        (listeners[event] ||= []).push(cb);
+        return () => {};
+      },
+      emit: (event: string, payload: any) => {
+        (listeners[event] || []).forEach(fn => fn(payload));
+      }
+    }
+  };
+});
+import bus from "../lib/bus";
 
 vi.mock("../lib/ensureModelViewer", () => ({
   ensureModelViewer: () => Promise.resolve()
@@ -25,6 +37,25 @@ describe("PostCard emoji accessibility", () => {
     const first = buttons[0] as HTMLButtonElement;
     first.focus();
     expect(document.activeElement).toBe(first);
+  });
+});
+
+describe("PostCard reactions", () => {
+  it("aggregates duplicate reactions", async () => {
+    const post = { id: 1 } as any;
+    const { container } = render(<PostCard post={post} />);
+    await new Promise(r => setTimeout(r, 0));
+    act(() => {
+      bus.emit("post:react", { id: 1, emoji: "🔥" });
+      bus.emit("post:react", { id: 1, emoji: "🔥" });
+      bus.emit("post:react", { id: 1, emoji: "✨" });
+    });
+    const items = Array.from(container.querySelectorAll(".pc-re"));
+    expect(items.length).toBe(2);
+    expect(items[0].textContent).toContain("🔥");
+    expect(items[0].textContent).toContain("2");
+    expect(items[1].textContent).toContain("✨");
+    expect(items[1].textContent).toContain("1");
   });
 });
 

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -18,7 +18,7 @@ const EMOJI_LIST: string[] = [
 export default function PostCard({ post }: { post: Post }) {
   const [drawer, setDrawer] = useState(false);
   const [comments, setComments] = useState<string[]>([]);
-  const [reactions, setReactions] = useState<string[]>([]);
+  const [reactions, setReactions] = useState<Record<string, number>>({});
 
   useEffect(() => {
     const off1 = bus.on?.("post:comment", ({ id, body }) => {
@@ -29,7 +29,11 @@ export default function PostCard({ post }: { post: Post }) {
     const off2 = bus.on?.("post:react", ({ id, emoji }) => {
       if (String(id) !== String(post.id)) return;
       setDrawer(true);
-      setReactions((s) => [emoji, ...s].slice(0, 60));
+      setReactions((s) => {
+        const out = { ...s };
+        out[emoji] = (out[emoji] || 0) + 1;
+        return out;
+      });
     });
     const off3 = bus.on?.("post:focus", ({ id }) => {
       if (String(id) !== String(post.id)) return;
@@ -227,7 +231,14 @@ export default function PostCard({ post }: { post: Post }) {
           <div className="pc-section">
             <strong>Reactions</strong>
             <div className="pc-reactions">
-              {reactions.length ? reactions.map((e, i) => <span key={i} className="pc-re">{e}</span>) : <span className="pc-empty">—</span>}
+              {Object.keys(reactions).length
+                ? Object.entries(reactions).map(([e, count]) => (
+                    <span key={e} className="pc-re">
+                      {e}
+                      <span className="pc-re-count">{count}</span>
+                    </span>
+                  ))
+                : <span className="pc-empty">—</span>}
             </div>
           </div>
 

--- a/src/components/postcard.css
+++ b/src/components/postcard.css
@@ -136,7 +136,8 @@
   scrollbar-width:none;
 }
 .pc-reactions::-webkit-scrollbar{ display:none; }
-.pc-re{ font-size:18px; }
+.pc-re{ display:inline-flex; align-items:center; gap:4px; font-size:18px; }
+.pc-re-count{ font-size:12px; background: rgba(255,255,255,.15); border-radius:999px; padding:0 4px; line-height:1; }
 .pc-comments{ list-style:none; margin:8px 0 0; padding:0; display:grid; gap:6px; }
 .pc-comments li{ background: rgba(255,255,255,.06); border:1px solid rgba(255,255,255,.12); padding:8px 10px; border-radius:10px; opacity:.95; }
 .pc-addcmt{ display:flex; gap:8px; margin-top:10px; }


### PR DESCRIPTION
## Summary
- Track post reactions in a `{emoji: count}` map instead of an array
- Display each reacted emoji once with a count badge
- Test reaction aggregation to ensure duplicate emoji are counted

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a21556cc4483219d63072cb159d8ad