### PR TITLE
feat: read OpenAI key from new storage key

### DIFF
--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -86,7 +86,17 @@ export async function askLLMVoice(
   let apiKey = "";
   if (typeof window !== "undefined") {
     try {
-      apiKey = window.localStorage.getItem("sn2177.apiKey") || "";
+      // New key (matches Sidebar.tsx)
+      const raw = window.localStorage.getItem("sn.keys.openai");
+      if (raw) {
+        try {
+          apiKey = String(JSON.parse(raw) ?? "").trim();
+        } catch {
+          apiKey = raw.trim();
+        }
+      }
+      // Legacy fallback
+      if (!apiKey) apiKey = window.localStorage.getItem("sn2177.apiKey") || "";
     } catch {
       apiKey = "";
     }


### PR DESCRIPTION
## Summary
- load OpenAI API key from `sn.keys.openai`
- retain legacy fallback to `sn2177.apiKey`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2153b5184832190b60ca4aa098b2c