### PR TITLE
test: cover Picsum fallback when API keys missing

### DIFF
--- a/src/lib/imageProviders.test.ts
+++ b/src/lib/imageProviders.test.ts
@@ -10,25 +10,24 @@ describe("fetchImages", () => {
 
   it("warns once and falls back to picsum when API key is missing", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const mockFetch = vi.fn(async (url: RequestInfo) => {
-      expect(String(url)).toContain("picsum.photos");
-      return {
-        ok: true,
-        json: async () => [
-          { id: 1, author: "a", url: "https://example.com", width: 100, height: 100 },
-        ],
-      } as any;
-    });
-    // @ts-ignore
-    global.fetch = mockFetch;
+    const mockFetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => [
+        { id: 1, author: "a", url: "https://example.com", width: 100, height: 100 },
+      ],
+    }));
+    global.fetch = mockFetch as any;
 
     const r1 = await fetchImages({ provider: "unsplash", page: 1, perPage: 1 });
     const r2 = await fetchImages({ provider: "unsplash", page: 1, perPage: 1 });
 
     expect(warn).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    for (const [url] of mockFetch.mock.calls) {
+      expect(String(url)).toContain("picsum.photos");
+    }
     expect(r1.length).toBe(1);
     expect(r2.length).toBe(1);
-    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 });
 


### PR DESCRIPTION
## Summary
- reset secure storage before each image provider test
- mock console.warn and verify Picsum fallback URL when API keys are missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a23d6abc688321a42fae2d0f2279c9