### PR TITLE
refactor: improve assistant error handling

### DIFF
--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -268,10 +268,21 @@ export default function AssistantOrb() {
           }
         : null
     );
-    push(resp);
+    if (resp.ok) {
+      push(resp.message);
+    } else {
+      setToast(resp.error);
+      push({
+        id: uuid(),
+        role: "assistant",
+        text: `⚠️ ${resp.error}`,
+        ts: Date.now(),
+        postId: post?.id ?? null,
+      });
+    }
 
     if (voiceOn) {
-      const stream = await askLLMVoice(
+      const streamResp = await askLLMVoice(
         T,
         post
           ? {
@@ -281,9 +292,9 @@ export default function AssistantOrb() {
             }
           : null
       );
-      if (stream) {
+      if (streamResp.ok) {
         try {
-          const blob = await new Response(stream).blob();
+          const blob = await new Response(streamResp.stream).blob();
           const url = URL.createObjectURL(blob);
           const el = audioRef.current;
           if (el) {

--- a/src/lib/assistant.test.ts
+++ b/src/lib/assistant.test.ts
@@ -32,7 +32,8 @@ describe("askLLM id generation", () => {
     });
 
     const msg = await askLLM("hello");
-    expect(msg.id).toBe(uuid);
+    expect(msg.ok).toBe(true);
+    expect(msg.message.id).toBe(uuid);
   });
 
   it("falls back to Math.random when crypto.randomUUID is unavailable", async () => {
@@ -47,6 +48,7 @@ describe("askLLM id generation", () => {
     Math.random = () => 0.123456789;
 
     const msg = await askLLM("hello");
-    expect(msg.id).toBe("4fzzzxjylrx");
+    expect(msg.ok).toBe(true);
+    expect(msg.message.id).toBe("4fzzzxjylrx");
   });
 });


### PR DESCRIPTION
## Summary
- add strict AskPayload/AskResult/AskVoiceResult types and notify through bus
- use AbortController timeouts and JSON/text error parsing
- handle voice API key lookup with warnOnce and audio stream validation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a23d5211708321a31937ee240c026e