### PR TITLE
feat: migrate legacy api key and support image provider keys

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -28,15 +28,30 @@ function useLocal<T>(key: string, init: T) {
   return [v, setV] as const;
 }
 
-function useSecure(key: string) {
-  const [v, setV] = useState(() =>
-    typeof window === "undefined" ? "" : getSecureKey(key),
-  );
+function useSecure(key: string, legacy?: string) {
+  const [v, setV] = useState(() => {
+    if (typeof window === "undefined") return "";
+    const current = getSecureKey(key);
+    if (current) return current;
+    return legacy ? getSecureKey(legacy) : "";
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !legacy) return;
+    const legacyVal = getSecureKey(legacy);
+    if (legacyVal) {
+      setSecureKey(key, legacyVal);
+      removeSecureKey(legacy);
+      setV(legacyVal);
+    }
+  }, [key, legacy]);
+
   const update = (val: string) => {
     setV(val);
     if (typeof window === "undefined") return;
     if (val) setSecureKey(key, val);
     else removeSecureKey(key);
+    if (legacy) removeSecureKey(legacy);
   };
   return [v, update] as const;
 }
@@ -86,12 +101,16 @@ export default function Sidebar() {
     document.documentElement.style.setProperty("--accent", accent);
   }, [accent]);
 
-  const [openaiKey, setOpenaiKey] = useSecure("openai");
+  const [openaiKey, setOpenaiKey] = useSecure("openai", "sn2177.apiKey");
   const [anthropicKey, setAnthropicKey] = useSecure("anthropic");
   const [perplexityKey, setPerplexityKey] = useSecure("perplexity");
+  const [unsplashKey, setUnsplashKey] = useSecure("unsplash");
+  const [pexelsKey, setPexelsKey] = useSecure("pexels");
   const [openaiDraft, setOpenaiDraft] = useState(openaiKey);
   const [anthropicDraft, setAnthropicDraft] = useState(anthropicKey);
   const [perplexityDraft, setPerplexityDraft] = useState(perplexityKey);
+  const [unsplashDraft, setUnsplashDraft] = useState(unsplashKey);
+  const [pexelsDraft, setPexelsDraft] = useState(pexelsKey);
   const [openaiModel, setOpenaiModel] = useLocal(
     "sn.model.openai",
     "gpt-4o-mini",
@@ -132,6 +151,28 @@ export default function Sidebar() {
       onClear: () => {
         setPerplexityDraft("");
         setPerplexityKey("");
+      },
+    },
+    {
+      id: "unsplash",
+      label: "Unsplash",
+      value: unsplashDraft,
+      onChange: setUnsplashDraft,
+      onSave: () => setUnsplashKey(unsplashDraft),
+      onClear: () => {
+        setUnsplashDraft("");
+        setUnsplashKey("");
+      },
+    },
+    {
+      id: "pexels",
+      label: "Pexels",
+      value: pexelsDraft,
+      onChange: setPexelsDraft,
+      onSave: () => setPexelsKey(pexelsDraft),
+      onClear: () => {
+        setPexelsDraft("");
+        setPexelsKey("");
       },
     },
   ];

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -34,7 +34,7 @@ interface PlayersJson {
 export async function assistantReply(
   prompt: string,
 ): Promise<AssistantReplyResult> {
-  const apiKey = getKey("openai") || getKey("sn2177.apiKey");
+  const apiKey = getKey("openai");
   if (!apiKey) warnOnce("Missing OpenAI API key");
 
   const payload: AssistantReplyPayload = { prompt };

--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -119,7 +119,7 @@ export async function askLLMVoice(
   prompt: string,
   ctx?: AssistantCtx,
 ): Promise<AskVoiceResult> {
-  const apiKey = getKey("openai") || getKey("sn2177.apiKey");
+  const apiKey = getKey("openai");
   if (!apiKey) {
     warnOnce("Missing OpenAI API key");
     return { ok: false, error: "missing api key" };


### PR DESCRIPTION
## Summary
- support migrating legacy `sn2177.apiKey` to canonical key in `useSecure`
- add secure Unsplash and Pexels key management in settings sidebar
- drop legacy OpenAI key lookup from assistant and api helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a23f62e3408321a16dbfd308c907e7