### PR TITLE
Emit toast events for warnings and errors

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,5 +1,7 @@
 // src/bootstrap.ts
 // Logs runtime errors early and shows a simple fallback message.
+import bus from "./lib/bus";
+
 function showFallback() {
   if (document.getElementById('bootstrap-error')) return;
   const el = document.createElement('p');
@@ -18,11 +20,15 @@ function showFallback() {
 }
 
 window.onerror = function (_message, _source, _lineno, _colno, error) {
+  const message = 'Uncaught error';
+  bus.emit?.('toast', { message });
   console.error('Uncaught error:', error);
   showFallback();
 };
 
 window.onunhandledrejection = function (event) {
+  const message = 'Unhandled promise rejection';
+  bus.emit?.('toast', { message });
   console.error('Unhandled promise rejection:', event.reason);
   showFallback();
 };

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from "react";
+import bus from "../lib/bus";
 
 type Props = {
   children: ReactNode;
@@ -27,6 +28,10 @@ export default class ErrorBoundary extends React.Component<Props, State> {
   componentDidCatch(error: unknown, info: React.ErrorInfo) {
     // Log with best-effort typing; don’t throw from here
     // eslint-disable-next-line no-console
+    const message = `ErrorBoundary caught: ${
+      (error as Error)?.message || String(error)
+    }`;
+    bus.emit?.("toast", { message });
     console.error("ErrorBoundary caught:", error, info);
     this.setState({ info });
   }

--- a/src/components/ToastContainer.test.tsx
+++ b/src/components/ToastContainer.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { act } from "react";
+import { test, expect } from "vitest";
+import ToastContainer from "./ToastContainer";
+import bus from "../lib/bus";
+
+test("shows toast message from bus", () => {
+  render(<ToastContainer />);
+  act(() => {
+    bus.emit("toast", { message: "hello" });
+  });
+  expect(screen.getByText("hello")).toBeTruthy();
+});

--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -6,8 +6,14 @@ export default function ToastContainer() {
   const [msg, setMsg] = useState("");
 
   useEffect(() => {
-    const off = on("notify", (m: string) => setMsg(m));
-    return off;
+    const offNotify = on("notify", (m: string) => setMsg(m));
+    const offToast = on("toast", ({ message }: { message: string }) =>
+      setMsg(message)
+    );
+    return () => {
+      offNotify();
+      offToast();
+    };
   }, []);
 
   useEffect(() => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -6,6 +6,7 @@ let warned = false;
 function warnOnce(msg: string) {
   if (warned) return;
   warned = true;
+  bus.emit("toast", { message: msg });
   console.warn(msg);
   bus.emit("notify", msg);
 }
@@ -89,7 +90,9 @@ export async function fetchPlayers(): Promise<Player[]> {
     try {
       data = (await r.json()) as PlayersJson;
     } catch (e: unknown) {
-      console.error("Failed to parse /api/players response", e);
+      const message = "Failed to parse /api/players response";
+      bus.emit("toast", { message });
+      console.error(message, e);
       return [];
     }
     if (data.ok && Array.isArray(data.players)) {
@@ -102,7 +105,9 @@ export async function fetchPlayers(): Promise<Player[]> {
     }
     return [];
   } catch (e: unknown) {
-    console.error("Failed to fetch players", e);
+    const message = "Failed to fetch players";
+    bus.emit("toast", { message });
+    console.error(message, e);
     return [];
   }
 }

--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -90,8 +90,10 @@ export async function askLLM(
 
     if (!res.ok) {
       const msg = await parseError(res);
+      const toast = `Assistant request failed: ${msg}`;
+      bus.emit?.("toast", { message: toast });
       console.error("assistant request failed:", msg);
-      bus.emit?.("notify", `Assistant request failed: ${msg}`);
+      bus.emit?.("notify", toast);
       return { ok: false, error: msg };
     }
 
@@ -109,8 +111,10 @@ export async function askLLM(
   } catch (e: any) {
     clearTimeout(timeout);
     const msg = e?.message || "request failed";
+    const toast = `Assistant request failed: ${msg}`;
+    bus.emit?.("toast", { message: toast });
     console.error("assistant request failed:", msg);
-    bus.emit?.("notify", `Assistant request failed: ${msg}`);
+    bus.emit?.("notify", toast);
     return { ok: false, error: msg };
   }
 }
@@ -144,24 +148,30 @@ export async function askLLMVoice(
 
     if (!res.ok) {
       const msg = await parseError(res);
+      const toast = `Assistant voice request failed: ${msg}`;
+      bus.emit?.("toast", { message: toast });
       console.error("assistant voice request failed:", msg);
-      bus.emit?.("notify", `Assistant voice request failed: ${msg}`);
+      bus.emit?.("notify", toast);
       return { ok: false, error: msg };
     }
 
     const type = res.headers.get("content-type") || "";
     if (!type.startsWith("audio/")) {
       const msg = await parseError(res);
+      const toast = `Assistant voice request failed: ${msg}`;
+      bus.emit?.("toast", { message: toast });
       console.error("assistant voice request failed:", msg);
-      bus.emit?.("notify", `Assistant voice request failed: ${msg}`);
+      bus.emit?.("notify", toast);
       return { ok: false, error: msg || "invalid content type" };
     }
 
     const body = res.body as ReadableStream<Uint8Array> | null;
     if (!body || typeof (body as any).getReader !== "function") {
       const msg = "invalid response body";
+      const toast = `Assistant voice request failed: ${msg}`;
+      bus.emit?.("toast", { message: toast });
       console.error("assistant voice request failed:", msg);
-      bus.emit?.("notify", `Assistant voice request failed: ${msg}`);
+      bus.emit?.("notify", toast);
       return { ok: false, error: msg };
     }
 
@@ -169,8 +179,10 @@ export async function askLLMVoice(
   } catch (e: any) {
     clearTimeout(timeout);
     const msg = e?.message || "request failed";
+    const toast = `Assistant voice request failed: ${msg}`;
+    bus.emit?.("toast", { message: toast });
     console.error("assistant voice request failed:", msg);
-    bus.emit?.("notify", `Assistant voice request failed: ${msg}`);
+    bus.emit?.("notify", toast);
     return { ok: false, error: msg };
   }
 }

--- a/src/lib/ensureModelViewer.ts
+++ b/src/lib/ensureModelViewer.ts
@@ -1,3 +1,5 @@
+import bus from "./bus";
+
 const REMOTE_SRC =
   'https://unpkg.com/@google/model-viewer@4.1.0/dist/model-viewer.min.js';
 const REMOTE_SRI =
@@ -40,7 +42,9 @@ export async function ensureModelViewer() {
   try {
     await load(REMOTE_SRC, REMOTE_SRI);
   } catch (err) {
-    console.warn('Falling back to local model-viewer', err);
+    const message = 'Falling back to local model-viewer';
+    bus.emit?.('toast', { message });
+    console.warn(message, err);
     await load(LOCAL_SRC);
   }
 }

--- a/src/lib/imageProviders.ts
+++ b/src/lib/imageProviders.ts
@@ -1,4 +1,5 @@
 import { getKey as getStoredKey } from "./secureStore";
+import bus from "./bus";
 
 export type FeedImage = {
   id: string;
@@ -39,7 +40,9 @@ function warnMissingKey(name: string) {
   const upper = name.toUpperCase();
   if (!warnedProviders.has(upper)) {
     warnedProviders.add(upper);
-    console.warn(`VITE_${upper}_KEY is not set; falling back to placeholder images`);
+    const message = `VITE_${upper}_KEY is not set; falling back to placeholder images`;
+    bus.emit?.('toast', { message });
+    console.warn(message);
   }
 }
 

--- a/src/lib/repost.ts
+++ b/src/lib/repost.ts
@@ -1,3 +1,5 @@
+import bus from "./bus";
+
 export type Platform = 'x' | 'facebook' | 'linkedin';
 
 /**
@@ -36,7 +38,9 @@ export async function repost(
     return true;
   } catch (err) {
     // eslint-disable-next-line no-console -- surface error for debugging
-    console.error('Repost failed', err);
+    const message = 'Repost failed';
+    bus.emit?.('toast', { message });
+    console.error(message, err);
     return false;
   }
 }

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,5 +1,6 @@
 // src/lib/share.ts
 import type { Post } from "../types";
+import bus from "./bus";
 
 /** Options version (Web Share friendly) */
 export interface ShareOptions {
@@ -66,7 +67,9 @@ export async function sharePost(arg: Post | ShareOptions | string): Promise<bool
   const ta = document.createElement("textarea");
   try {
     if (!document.body) {
-      console.error("sharePost: document.body is not available");
+      const message = "sharePost: document.body is not available";
+      bus.emit?.('toast', { message });
+      console.error(message);
       return false;
     }
 
@@ -77,11 +80,15 @@ export async function sharePost(arg: Post | ShareOptions | string): Promise<bool
     ta.select();
     const success = document.execCommand("copy");
     if (!success) {
-      console.error("sharePost: copy command failed");
+      const message = "sharePost: copy command failed";
+      bus.emit?.('toast', { message });
+      console.error(message);
     }
     return success;
   } catch (err) {
-    console.error("sharePost: unable to copy", err);
+    const message = "sharePost: unable to copy";
+    bus.emit?.('toast', { message });
+    console.error(message, err);
     return false;
   } finally {
     if (document.body && ta.parentNode === document.body) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import App from "./App";
 import { setSuperUserKey } from "./lib/superUser";
+import bus from "./lib/bus";
 
 const initialSuperKey = (() => {
   try {
@@ -17,7 +18,9 @@ setSuperUserKey(initialSuperKey);
 
 const root = document.getElementById("root");
 if (!root) {
-  console.error("Missing #root element – app cannot mount.");
+  const message = "Missing #root element – app cannot mount.";
+  bus.emit?.("toast", { message });
+  console.error(message);
   const fallback = document.createElement("p");
   fallback.textContent = "An unexpected error occurred while loading the app.";
   document.body.appendChild(fallback);


### PR DESCRIPTION
## Summary
- show toast notifications wherever console warnings or errors occur
- hook ToastContainer up to new `toast` bus events and verify with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a23f677a7c832194ba5caff2e66bad