### PR TITLE
Guard askLLM test results and exclude test files from TS build

### DIFF
--- a/src/lib/assistant.test.ts
+++ b/src/lib/assistant.test.ts
@@ -31,9 +31,10 @@ describe("askLLM id generation", () => {
       configurable: true,
     });
 
-    const msg = await askLLM("hello");
-    expect(msg.ok).toBe(true);
-    expect(msg.message.id).toBe(uuid);
+    const result = await askLLM("hello");
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.message.id).toBe(uuid);
   });
 
   it("falls back to Math.random when crypto.randomUUID is unavailable", async () => {
@@ -47,8 +48,9 @@ describe("askLLM id generation", () => {
     delete global.crypto;
     Math.random = () => 0.123456789;
 
-    const msg = await askLLM("hello");
-    expect(msg.ok).toBe(true);
-    expect(msg.message.id).toBe("4fzzzxjylrx");
+    const result = await askLLM("hello");
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.message.id).toBe("4fzzzxjylrx");
   });
 });

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -20,5 +20,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,6 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
## Summary
- ensure askLLM tests verify ok and throw if error before reading message
- exclude `.test.ts` and `.test.tsx` from TypeScript build configs

## Testing
- `npm test`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68a240266e5483218cc880caa3640322