### PR TITLE
feat: add global warnOnce helper for API keys

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,14 +1,6 @@
 // src/lib/api.ts
 import { getKey } from "./secureStore";
-import bus from "./bus";
-
-let warned = false;
-function warnOnce(msg: string) {
-  if (warned) return;
-  warned = true;
-  console.warn(msg);
-  bus.emit("notify", msg);
-}
+import { warnMissingKey } from "./warnOnce";
 
 interface AssistantReplyPayload {
   prompt: string;
@@ -35,7 +27,7 @@ export async function assistantReply(
   prompt: string,
 ): Promise<AssistantReplyResult> {
   const apiKey = getKey("openai") || getKey("sn2177.apiKey");
-  if (!apiKey) warnOnce("Missing OpenAI API key");
+  if (!apiKey) warnMissingKey("openai", "Missing OpenAI API key");
 
   const payload: AssistantReplyPayload = { prompt };
   if (apiKey) payload.apiKey = apiKey;

--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -2,6 +2,7 @@
 import type { AssistantMessage, RemixSpec } from "../types";
 import bus from "./bus";
 import { getKey } from "./secureStore";
+import { warnMissingKey } from "./warnOnce";
 
 type AssistantCtx = {
   postId?: string | number;
@@ -23,15 +24,6 @@ export type AskVoiceResult =
   | { ok: true; stream: ReadableStream<Uint8Array> }
   | { ok: false; error: string };
 
-const warnOnce = (() => {
-  let warned = false;
-  return (msg: string) => {
-    if (!warned) {
-      warned = true;
-      bus.emit?.("notify", msg);
-    }
-  };
-})();
 
 async function parseError(res: Response): Promise<string> {
   try {
@@ -121,7 +113,7 @@ export async function askLLMVoice(
 ): Promise<AskVoiceResult> {
   const apiKey = getKey("openai") || getKey("sn2177.apiKey");
   if (!apiKey) {
-    warnOnce("Missing OpenAI API key");
+    warnMissingKey("openai", "Missing OpenAI API key");
     return { ok: false, error: "missing api key" };
   }
 

--- a/src/lib/warnOnce.ts
+++ b/src/lib/warnOnce.ts
@@ -1,0 +1,14 @@
+// src/lib/warnOnce.ts
+import bus from "./bus";
+
+const WARN_KEY = "__snWarnedMissingKeys";
+const warned: Set<string> =
+  (globalThis as any)[WARN_KEY] || ((globalThis as any)[WARN_KEY] = new Set<string>());
+
+export function warnMissingKey(name: string, message: string) {
+  if (warned.has(name)) return;
+  warned.add(name);
+  console.warn(message);
+  bus.emit?.("notify", message);
+}
+


### PR DESCRIPTION
## Summary
- add warnMissingKey helper with global Set to only warn once per key
- use warnMissingKey in api and assistant modules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a23f660b5c8321a7c9722211434de7