### PR TITLE
refactor: centralize assistant warnings

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3,11 +3,28 @@ import { getKey } from "./secureStore";
 import bus from "./bus";
 
 let warned = false;
-function warnOnce(msg: string) {
+export function warnOnce(msg: string) {
   if (warned) return;
   warned = true;
   console.warn(msg);
-  bus.emit("notify", msg);
+  bus.emit("toast", { message: msg });
+}
+
+export async function parseError(res: Response): Promise<string> {
+  try {
+    const data = await res.json();
+    return (
+      (data && (data.error || data.message)) ||
+      (typeof data === "string" ? data : JSON.stringify(data)) ||
+      "request failed"
+    );
+  } catch {
+    try {
+      return (await res.text()) || "request failed";
+    } catch {
+      return "request failed";
+    }
+  }
 }
 
 interface AssistantReplyPayload {


### PR DESCRIPTION
## Summary
- centralize `warnOnce` and `parseError` helpers in `api.ts`
- fetch OpenAI keys from secure store in assistant helpers with toast warnings
- streamline assistant request error handling and validation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a23f61d490832191598baa5ba20214