### PR TITLE
Refactor assistant test error handling

### DIFF
--- a/src/lib/assistant.test.ts
+++ b/src/lib/assistant.test.ts
@@ -31,11 +31,10 @@ describe("askLLM id generation", () => {
       configurable: true,
     });
 
-    const msg = await askLLM("hello");
-    expect(msg.ok).toBe(true);
-    if (msg.ok) {
-      expect(msg.message.id).toBe(uuid);
-    }
+    const result = await askLLM("hello");
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.message.id).toBe(uuid);
   });
 
   it("falls back to Math.random when crypto.randomUUID is unavailable", async () => {
@@ -49,10 +48,9 @@ describe("askLLM id generation", () => {
     delete global.crypto;
     Math.random = () => 0.123456789;
 
-    const msg = await askLLM("hello");
-    expect(msg.ok).toBe(true);
-    if (msg.ok) {
-      expect(msg.message.id).toBe("4fzzzxjylrx");
-    }
+    const result = await askLLM("hello");
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.message.id).toBe("4fzzzxjylrx");
   });
 });


### PR DESCRIPTION
## Summary
- Ensure askLLM tests consistently name response `result` and assert success
- Add explicit error throw before accessing `result.message`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a242eb93a883219f27a878755bf05e