### PR TITLE
chore: exclude tests from tsc build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,6 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [],
+  "include": ["src", "src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
@@ -17,6 +17,12 @@ export default defineConfig({
           }
         },
       },
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    typecheck: {
+      tsconfig: './tsconfig.test.json',
     },
   },
 });


### PR DESCRIPTION
## Summary
- exclude test files from the TypeScript build
- add dedicated tsconfig for Vitest and configure tests to use it

## Testing
- `npx tsc -b && echo "tsc succeeded"`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a242ed75a4832190da3e96eecfe1b6