### PR TITLE
refactor: clarify askLLM test result handling

### DIFF
--- a/src/lib/assistant.test.ts
+++ b/src/lib/assistant.test.ts
@@ -31,11 +31,10 @@ describe("askLLM id generation", () => {
       configurable: true,
     });
 
-    const msg = await askLLM("hello");
-    expect(msg.ok).toBe(true);
-    if (msg.ok) {
-      expect(msg.message.id).toBe(uuid);
-    }
+    const result = await askLLM("hello");
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.message.id).toBe(uuid);
   });
 
   it("falls back to Math.random when crypto.randomUUID is unavailable", async () => {
@@ -49,10 +48,9 @@ describe("askLLM id generation", () => {
     delete global.crypto;
     Math.random = () => 0.123456789;
 
-    const msg = await askLLM("hello");
-    expect(msg.ok).toBe(true);
-    if (msg.ok) {
-      expect(msg.message.id).toBe("4fzzzxjylrx");
-    }
+    const result = await askLLM("hello");
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.message.id).toBe("4fzzzxjylrx");
   });
 });


### PR DESCRIPTION
## Summary
- rename askLLM test call results to `result`
- assert success and throw on failure before reading message id

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a24401e5f483218c73a46ec3790cb5