### PR TITLE
Refactor AssistantOrb to use speech hook

### DIFF
--- a/src/lib/useSpeech.test.ts
+++ b/src/lib/useSpeech.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import useSpeechRecognition from "./useSpeech";
+import useSpeech from "./useSpeech";
 import { logError } from "./logger";
 
 vi.mock("./logger", () => ({
   logError: vi.fn(),
 }));
 
-describe("useSpeechRecognition", () => {
+describe("useSpeech", () => {
   afterEach(() => {
     delete (globalThis as any).SpeechRecognition;
   });
@@ -28,7 +28,7 @@ describe("useSpeechRecognition", () => {
     }
     (globalThis as any).SpeechRecognition = MockSpeechRecognition as any;
 
-    const { result } = renderHook(() => useSpeechRecognition(() => {}));
+    const { result } = renderHook(() => useSpeech({ onResult: () => {} }));
 
     const evt = new Error("fail");
     act(() => {

--- a/src/lib/useSpeech.ts
+++ b/src/lib/useSpeech.ts
@@ -2,11 +2,30 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { logError } from "./logger";
 
-type ResultHandler = (text: string) => void | Promise<void>;
+interface SpeechOptions {
+  onResult: (text: string) => void | Promise<void>;
+  onInterim?: (text: string) => void | Promise<void>;
+  onStart?: () => void;
+  onEnd?: () => void;
+  onError?: (e: unknown) => void;
+}
 
-export default function useSpeechRecognition(onResult: ResultHandler) {
+/**
+ * Thin wrapper around the Web Speech API.
+ * Handles restart logic, final and interim results, and exposes start/stop
+ * methods. Consumers can subscribe to lifecycle callbacks.
+ */
+export default function useSpeech({
+  onResult,
+  onInterim,
+  onStart,
+  onEnd,
+  onError,
+}: SpeechOptions) {
   const recRef = useRef<any>(null);
+  const activeRef = useRef(false);
   const [error, setError] = useState<string>("");
+
   const supported =
     typeof window !== "undefined" &&
     ((window as any).SpeechRecognition || (window as any).webkitSpeechRecognition);
@@ -22,38 +41,85 @@ export default function useSpeechRecognition(onResult: ResultHandler) {
       setError("Speech recognition unavailable");
       return;
     }
+
     rec.lang = "en-US";
-    rec.interimResults = false;
+    rec.continuous = true;
+    rec.interimResults = !!onInterim;
     rec.maxAlternatives = 1;
-    rec.onresult = async (e: any) => {
-      try {
-        const txt = e.results && e.results[0] && e.results[0][0] && e.results[0][0].transcript;
-        if (txt) await onResult(txt);
-      } catch (err) {
-        // ignore handler errors but log
-        logError(err);
-      } finally {
-        try { rec.stop(); } catch (err) { logError(err); }
+
+    rec.onstart = () => {
+      onStart?.();
+    };
+
+    rec.onend = () => {
+      onEnd?.();
+      // Safari ends even with continuous=true; restart if still active
+      if (activeRef.current) {
+        try {
+          rec.start();
+        } catch (err) {
+          logError(err);
+        }
       }
     };
+
     rec.onerror = (e: unknown) => {
       logError(e);
       setError("Speech recognition failed");
+      onError?.(e);
     };
+
+    rec.onresult = async (e: any) => {
+      try {
+        if (onInterim) {
+          let temp = "";
+          const finals: string[] = [];
+          for (let i = e.resultIndex; i < e.results.length; i++) {
+            const r = e.results[i];
+            const t = r[0] && r[0].transcript ? r[0].transcript : "";
+            r.isFinal ? finals.push(t) : (temp += t);
+          }
+          onInterim(temp.trim());
+          const final = finals.join(" ").trim();
+          if (final) await onResult(final);
+        } else {
+          const txt = e.results && e.results[0] && e.results[0][0] && e.results[0][0].transcript;
+          if (txt) await onResult(txt);
+        }
+      } catch (err) {
+        logError(err);
+      }
+    };
+
     recRef.current = rec;
     return () => {
-      try { rec.stop(); } catch (err) { logError(err); }
+      try {
+        rec.stop();
+      } catch (err) {
+        logError(err);
+      }
       recRef.current = null;
     };
-  }, [onResult, supported]);
+  }, [onResult, onInterim, onStart, onEnd, onError, supported]);
 
   const start = useCallback(() => {
-    try { recRef.current && recRef.current.start(); } catch (err) { logError(err); }
+    activeRef.current = true;
+    try {
+      recRef.current && recRef.current.start();
+    } catch (err) {
+      logError(err);
+    }
   }, []);
 
   const stop = useCallback(() => {
-    try { recRef.current && recRef.current.stop(); } catch (err) { logError(err); }
+    activeRef.current = false;
+    try {
+      recRef.current && recRef.current.stop();
+    } catch (err) {
+      logError(err);
+    }
   }, []);
 
   return { start, stop, supported: !!supported, error };
 }
+


### PR DESCRIPTION
## Summary
- Simplify AssistantOrb speech recognition by using the `useSpeech` hook and integrating orb state callbacks
- Extend `useSpeech` with lifecycle and interim-result support for richer voice UX

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a24689ebdc832183d59218994f2334