### PR TITLE
Persist API keys in secure local storage

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -111,6 +111,14 @@ export default function Sidebar() {
   const [perplexityDraft, setPerplexityDraft] = useState(perplexityKey);
   const [unsplashDraft, setUnsplashDraft] = useState(unsplashKey);
   const [pexelsDraft, setPexelsDraft] = useState(pexelsKey);
+
+  useEffect(() => {
+    setOpenaiDraft(openaiKey);
+    setAnthropicDraft(anthropicKey);
+    setPerplexityDraft(perplexityKey);
+    setUnsplashDraft(unsplashKey);
+    setPexelsDraft(pexelsKey);
+  }, [openaiKey, anthropicKey, perplexityKey, unsplashKey, pexelsKey]);
   const [openaiModel, setOpenaiModel] = useLocal(
     "sn.model.openai",
     "gpt-4o-mini",
@@ -126,7 +134,7 @@ export default function Sidebar() {
       value: openaiDraft,
       onChange: setOpenaiDraft,
       onSave: () => setOpenaiKey(openaiDraft),
-      onClear: () => {
+      onRemove: () => {
         setOpenaiDraft("");
         setOpenaiKey("");
       },
@@ -137,7 +145,7 @@ export default function Sidebar() {
       value: anthropicDraft,
       onChange: setAnthropicDraft,
       onSave: () => setAnthropicKey(anthropicDraft),
-      onClear: () => {
+      onRemove: () => {
         setAnthropicDraft("");
         setAnthropicKey("");
       },
@@ -148,7 +156,7 @@ export default function Sidebar() {
       value: perplexityDraft,
       onChange: setPerplexityDraft,
       onSave: () => setPerplexityKey(perplexityDraft),
-      onClear: () => {
+      onRemove: () => {
         setPerplexityDraft("");
         setPerplexityKey("");
       },
@@ -159,7 +167,7 @@ export default function Sidebar() {
       value: unsplashDraft,
       onChange: setUnsplashDraft,
       onSave: () => setUnsplashKey(unsplashDraft),
-      onClear: () => {
+      onRemove: () => {
         setUnsplashDraft("");
         setUnsplashKey("");
       },
@@ -170,7 +178,7 @@ export default function Sidebar() {
       value: pexelsDraft,
       onChange: setPexelsDraft,
       onSave: () => setPexelsKey(pexelsDraft),
-      onClear: () => {
+      onRemove: () => {
         setPexelsDraft("");
         setPexelsKey("");
       },
@@ -373,7 +381,7 @@ export default function Sidebar() {
             <header>API Keys</header>
             <div className="keys">
               {keyFields.map(
-                ({ id, label, value, onChange, onSave, onClear }) => (
+                ({ id, label, value, onChange, onSave, onRemove }) => (
                   <div key={id} className="key-field">
                     <label className="label" htmlFor={`key-${id}`}>
                       {label}
@@ -396,8 +404,8 @@ export default function Sidebar() {
                       <button className="key-toggle" onClick={onSave} type="button">
                         Save
                       </button>
-                      <button className="key-toggle" onClick={onClear} type="button">
-                        Clear
+                      <button className="key-toggle" onClick={onRemove} type="button">
+                        Remove
                       </button>
                     </div>
                   </div>

--- a/src/lib/imageProviders.test.ts
+++ b/src/lib/imageProviders.test.ts
@@ -3,11 +3,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // Tests dynamically import modules so that module-level state like warnedProviders
 // is reset between cases and environment variables are applied before import.
 describe("fetchImages", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.resetModules();
     vi.restoreAllMocks();
     delete process.env.VITE_UNSPLASH_KEY;
     delete process.env.VITE_PEXELS_KEY;
+    if (typeof localStorage !== "undefined") localStorage.clear();
+    const secure = await import("./secureStore");
+    secure.clearAll();
   });
 
   it("uses VITE_UNSPLASH_KEY before secureStore", async () => {

--- a/src/lib/secureStore.ts
+++ b/src/lib/secureStore.ts
@@ -1,17 +1,53 @@
 const store: Record<string, string> = {};
 
+function encode(val: string): string {
+  try {
+    if (typeof btoa === "function") return btoa(val);
+    return Buffer.from(val, "utf-8").toString("base64");
+  } catch {
+    return val;
+  }
+}
+
+function decode(val: string): string {
+  try {
+    if (typeof atob === "function") return atob(val);
+    return Buffer.from(val, "base64").toString("utf-8");
+  } catch {
+    return val;
+  }
+}
+
 export function getKey(name: string): string {
-  return store[name] || "";
+  if (store[name]) return store[name];
+  if (typeof localStorage === "undefined") return "";
+  try {
+    const raw = localStorage.getItem(name);
+    if (!raw) return "";
+    const val = decode(raw);
+    store[name] = val;
+    return val;
+  } catch {
+    return "";
+  }
 }
 
 export function setKey(name: string, value: string): void {
   store[name] = value;
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(name, encode(value));
+  } catch {}
 }
 
 export function removeKey(name: string): void {
   delete store[name];
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.removeItem(name);
+  } catch {}
 }
 
 export function clearAll(): void {
-  for (const k of Object.keys(store)) delete store[k];
+  for (const k of Object.keys(store)) removeKey(k);
 }


### PR DESCRIPTION
## Summary
- persist secureStore keys to localStorage with simple base64 encoding
- auto-populate API key fields from stored values and provide a remove button
- reset image provider tests between runs to clear persistent keys

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a246890fb08321833d63cf4a381dd7