### PR TITLE
refactor: handle assistant response

### DIFF
--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -326,15 +326,18 @@ export default function AssistantOrb() {
         : null
     );
     let replyText: string | null = null;
-    if (resp.ok && resp.message) {
-      push(resp.message);
-      replyText = resp.message.text;
+    if (resp.ok) {
+      if (resp.message) {
+        push(resp.message);
+        replyText = resp.message.text;
+      }
     } else {
-      setToast(resp.error);
+      const err = resp.error ?? "Unknown error";
+      setToast(err);
       push({
         id: uuid(),
         role: "assistant",
-        text: `⚠️ ${resp.error}`,
+        text: `⚠️ ${err}`,
         ts: Date.now(),
         postId: post?.id ?? null,
       });


### PR DESCRIPTION
## Summary
- restructure assistant response handling to test `resp.ok` before accessing message
- guard against missing `resp.error` and show warning when request fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2476ebd5083218f709635eb345fcf