### PR TITLE
fix: ensure ArrayBuffer used for appendBuffer

### DIFF
--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -378,7 +378,7 @@ export default function AssistantOrb() {
               const pump = async (): Promise<void> => {
                 try {
                   const { value, done } = await reader.read();
-                  if (done) {
+                  if (done || !value) {
                     if (!sourceBuffer.updating) mediaSource.endOfStream();
                     else
                       sourceBuffer.addEventListener(
@@ -390,7 +390,8 @@ export default function AssistantOrb() {
                   }
                   loaded += value.byteLength;
                   bus.emit?.("voice:progress", { loaded });
-                  sourceBuffer.appendBuffer(value);
+                  // value is a Uint8Array; append its underlying ArrayBuffer
+                  sourceBuffer.appendBuffer(value.buffer as ArrayBuffer);
                   await new Promise((r) =>
                     sourceBuffer.addEventListener("updateend", r, { once: true }),
                   );


### PR DESCRIPTION
## Summary
- ensure voice streaming uses ArrayBuffer when appending source buffer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2476fb45c832191f34a19249ec510