### PR TITLE
Add selection & image context to assistant

### DIFF
--- a/api/assistant-reply.ts
+++ b/api/assistant-reply.ts
@@ -18,6 +18,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       postId?: string | number;
       title?: string;
       text?: string;
+      selection?: string;
+      images?: string[];
       post?: { id?: string | number; title?: string; text?: string };
     };
   };
@@ -60,6 +62,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const ctxTitle = ctx.title ?? ctx.post?.title;
   const ctxTextRaw = ctx.text ?? ctx.post?.text;
   const ctxText = typeof ctxTextRaw === "string" ? ctxTextRaw.slice(0, 1000) : "";
+  const ctxSelection =
+    typeof ctx.selection === "string" ? ctx.selection.slice(0, 1000) : "";
+  const ctxImages = Array.isArray(ctx.images)
+    ? ctx.images.filter((u): u is string => typeof u === "string").slice(0, 5)
+    : [];
 
   const messages: Array<{ role: "system" | "user"; content: string }> = [
     {
@@ -78,6 +85,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       role: "system",
       content: `Context from hovered post — ${parts.join(" — ")}`,
     });
+  }
+
+  if (ctxSelection) {
+    messages.push({ role: "system", content: `User selected text: ${ctxSelection}` });
+  }
+
+  if (ctxImages.length) {
+    messages.push({ role: "system", content: `Image URLs: ${ctxImages.join(", ")}` });
   }
 
   messages.push({ role: "user", content: prompt });

--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -7,6 +7,8 @@ type AssistantCtx = {
   postId?: string | number;
   title?: string;
   text?: string;
+  selection?: string;
+  images?: string[];
 } | null;
 
 export type AskPayload = {


### PR DESCRIPTION
## Summary
- capture highlighted text and post images in AssistantOrb and pass as context
- extend assistant API types to include selection and images
- include selected text and image URLs in system context for assistant replies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a24757c3188321bdb771b9534f8e66