### PR TITLE
feat: contextual voice assistant

### DIFF
--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -314,17 +314,22 @@ export default function AssistantOrb() {
       return;
     }
 
-    // Ask the model with optional post context (id, title, and visible text)
-    const resp = await askLLM(
-      T,
+    // Ask the model with optional post context
+    const ctx =
       post
         ? {
             postId: post.id as unknown as string | number,
             title: (post as any)?.title,
             text: ctxPostText || getPostText(post),
+            selection: ctxPostText || undefined,
+            imageUrl:
+              (post as any)?.images?.[0] ||
+              (post as any)?.image ||
+              (post as any)?.cover,
           }
-        : null
-    );
+        : null;
+
+    const resp = await askLLM(T, ctx);
     let replyText: string | null = null;
     if (resp.ok && resp.message) {
       push(resp.message);
@@ -344,16 +349,7 @@ export default function AssistantOrb() {
       const id = ++inFlightIdRef.current;
       audioRef.current?.pause();
 
-      const streamResp = await askLLMVoice(
-        replyText,
-        post
-          ? {
-              postId: post.id as unknown as string | number,
-              title: (post as any)?.title,
-              text: ctxPostText || getPostText(post),
-            }
-          : null
-      );
+      const streamResp = await askLLMVoice(replyText, ctx);
       if (id !== inFlightIdRef.current) return;
       if (streamResp.ok) {
         try {

--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -7,6 +7,8 @@ type AssistantCtx = {
   postId?: string | number;
   title?: string;
   text?: string;
+  selection?: string;
+  imageUrl?: string;
 } | null;
 
 export type AskPayload = {


### PR DESCRIPTION
## Summary
- add optional context to `/api/assistant-voice` and use chat completion to build speech text
- pass context (post id, selected text, image) through assistant helpers
- forward post context from AssistantOrb when requesting voice

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2474d77208321af38f617e15a91c5