### PR TITLE
feat: enrich assistant context with selections and images

### DIFF
--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -3,10 +3,11 @@ import type { AssistantMessage, RemixSpec } from "../types";
 import bus from "./bus";
 import { getKey } from "./secureStore";
 
-type AssistantCtx = {
+export type AssistantCtx = {
   postId?: string | number;
   title?: string;
   text?: string;
+  imageUrl?: string;
 } | null;
 
 export type AskPayload = {


### PR DESCRIPTION
## Summary
- capture selected text and image URLs from feed events
- send selection/image info to Assistant context
- extend AssistantCtx with optional imageUrl field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2468612e883219109e39f79a0aba8