### PR TITLE
Simplify assistant response handling

### DIFF
--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -271,7 +271,7 @@ export default function AssistantOrb() {
         : null
     );
     let replyText: string | null = null;
-    if (resp.ok && resp.message) {
+    if (resp.ok) {
       push(resp.message);
       replyText = resp.message.text;
     } else {


### PR DESCRIPTION
## Summary
- simplify handling of assistant replies by checking only `resp.ok`
- show assistant error toast when request fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a247f5826c8321a406ce621b3e1541