### PR TITLE
fix: cast voice audio to BlobPart

### DIFF
--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -322,7 +322,12 @@ export default function AssistantOrb() {
         try {
           const el = audioRef.current;
           if (el) {
-            const blob = new Blob([voiceResp.audio], { type: voiceResp.type });
+            // voiceResp.audio is a Uint8Array from the API; cast through
+            // unknown to BlobPart to satisfy the Blob constructor's type
+            // expectations.
+            const blob = new Blob([
+              voiceResp.audio as unknown as BlobPart,
+            ], { type: voiceResp.type });
             const url = URL.createObjectURL(blob);
             if (audioUrlRef.current) URL.revokeObjectURL(audioUrlRef.current);
             if (id !== inFlightIdRef.current) {


### PR DESCRIPTION
## Summary
- cast `voiceResp.audio` to `BlobPart` when creating Blob for playback
- document why casting through `unknown` is safe

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a24f7e73788321a56dc654b236f0d8