### PR TITLE
Use ArrayBuffer for assistant voice result

### DIFF
--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -23,7 +23,7 @@ export type AskResult =
   | { ok: false; error: string };
 
 export type AskVoiceResult =
-  | { ok: true; audio: Uint8Array; type: string; text?: string }
+  | { ok: true; audio: ArrayBuffer; type: string; text?: string }
   | { ok: false; error: string };
 
 const warnOnce = (() => {
@@ -179,7 +179,7 @@ export async function askLLMVoice(
     const bytes = new Uint8Array(len);
     for (let i = 0; i < len; i++) bytes[i] = binaryString.charCodeAt(i);
 
-    return { ok: true, audio: bytes, type, text: data?.text };
+    return { ok: true, audio: bytes.buffer, type, text: data?.text };
   } catch (e: any) {
     clearTimeout(timeout);
     const rawMsg = e?.message || "request failed";


### PR DESCRIPTION
## Summary
- Switch `AskVoiceResult` audio payload to `ArrayBuffer` and return `bytes.buffer`
- Ensure voice responses are consumed directly by `Blob`

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a24f7d06b88321af61fbb34797a84a