### PR TITLE
Fix voice response Blob for audio playback

### DIFF
--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -322,7 +322,7 @@ export default function AssistantOrb() {
         try {
           const el = audioRef.current;
           if (el) {
-            const blob = new Blob([voiceResp.audio], { type: voiceResp.type });
+            const blob = new Blob([voiceResp.audio.buffer as ArrayBuffer], { type: voiceResp.type });
             const url = URL.createObjectURL(blob);
             if (audioUrlRef.current) URL.revokeObjectURL(audioUrlRef.current);
             if (id !== inFlightIdRef.current) {


### PR DESCRIPTION
## Summary
- Use `voiceResp.audio.buffer` when constructing the audio `Blob` to satisfy TypeScript

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a24f7bd6fc83219471b865c1ba5034