### PR TITLE
fix: convert voice bytes to array buffer before blob

### DIFF
--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -93,7 +93,9 @@ async function readAudioStream(res: Response): Promise<{
     offset += c.length;
   }
   const type = res.headers.get("content-type") || "audio/mpeg";
-  const blob = new Blob([bytes], { type });
+  // Convert to ArrayBuffer before creating a Blob to satisfy DOM typings
+  const arrayBuffer = bytes.buffer as ArrayBuffer;
+  const blob = new Blob([arrayBuffer], { type });
   const url = URL.createObjectURL(blob);
   return { bytes, url, type };
 }


### PR DESCRIPTION
## Summary
- convert audio bytes to an ArrayBuffer before creating a Blob to satisfy type checks

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a250c9526c8321b24bbf3f1cb84a32