### PR TITLE
Use client-supplied OpenAI keys for assistants and clarify sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Fetching images from Unsplash or Pexels requires API keys. Set the following var
 - `VITE_UNSPLASH_KEY` – Unsplash access key
 - `VITE_PEXELS_KEY` – Pexels API key
 
-The app reads these values from `import.meta.env` and falls back to any keys stored in the in-memory secure store for local testing.
+For voice and text assistant features, supply your OpenAI API key inside the app instead of via environment variables. Open the sidebar and enter it in the **OpenAI (voice & text assistants)** field; the key is stored locally in your browser.
+
+The app reads the Unsplash and Pexels values from `import.meta.env` and falls back to any keys stored in the in-memory secure store for local testing.
 
 ### Adding keys on Vercel
 

--- a/api/assist.ts
+++ b/api/assist.ts
@@ -23,7 +23,7 @@ export default async function handler(req: Request): Promise<Response> {
   const bodyKey: string | undefined = typeof body?.apiKey === 'string' ? body.apiKey : undefined;
   const authHeader = req.headers.get('authorization') || '';
   const headerKey = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : undefined;
-  const apiKey = bodyKey || headerKey || process.env.OPENAI_API_KEY;
+  const apiKey = bodyKey || headerKey;
 
   if (!text) {
     return new Response(JSON.stringify({ error: 'Missing text' }), {

--- a/api/assistant-reply.ts
+++ b/api/assistant-reply.ts
@@ -27,16 +27,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     typeof req.headers.authorization === "string"
       ? req.headers.authorization.replace(/^Bearer\s+/i, "").trim()
       : "";
-  // For local dev the client may supply an OpenAI key; production should set OPENAI_API_KEY on the server.
-  const apiKey =
-    (headerKey || (typeof body.apiKey === "string" ? body.apiKey.trim() : "")) ||
-    (process.env.OPENAI_API_KEY || "");
+  const apiKey = headerKey || (typeof body.apiKey === "string" ? body.apiKey.trim() : "");
 
   if (!apiKey) {
     return res.status(401).json({
       ok: false,
       error:
-        "Unauthorized: missing OpenAI API key. Provide one in the request or set OPENAI_API_KEY on the server.",
+        "Unauthorized: missing OpenAI API key. Provide one in the request header or body.",
     });
   }
 

--- a/api/assistant-voice.ts
+++ b/api/assistant-voice.ts
@@ -28,15 +28,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       ? req.headers.authorization.replace(/^Bearer\s+/i, "").trim()
       : "";
 
-  const apiKey =
-    (headerKey || (typeof body.apiKey === "string" ? body.apiKey.trim() : "")) ||
-    (process.env.OPENAI_API_KEY || "");
+  const apiKey = headerKey || (typeof body.apiKey === "string" ? body.apiKey.trim() : "");
 
   if (!apiKey) {
     return res.status(401).json({
       ok: false,
       error:
-        "Unauthorized: missing OpenAI API key. Provide one in the request or set OPENAI_API_KEY on the server.",
+        "Unauthorized: missing OpenAI API key. Provide one in the request header or body.",
     });
   }
 

--- a/api/assistant.ts
+++ b/api/assistant.ts
@@ -26,15 +26,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       ? req.headers.authorization.replace(/^Bearer\s+/i, "").trim()
       : "";
 
-  const apiKey =
-    (headerKey || (typeof body.apiKey === "string" ? body.apiKey.trim() : "")) ||
-    (process.env.OPENAI_API_KEY || "");
+  const apiKey = headerKey || (typeof body.apiKey === "string" ? body.apiKey.trim() : "");
 
   if (!apiKey) {
     return res.status(401).json({
       ok: false,
       error:
-        "Unauthorized: missing OpenAI API key. Provide one in the request or set OPENAI_API_KEY on the server.",
+        "Unauthorized: missing OpenAI API key. Provide one in the request header or body.",
     });
   }
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -130,9 +130,12 @@ export default function Sidebar() {
   const keyFields = [
     {
       id: "openai",
-      label: "OpenAI",
+      label: "OpenAI (voice & text assistants)",
       value: openaiDraft,
-      onChange: setOpenaiDraft,
+      onChange: (v: string) => {
+        setOpenaiDraft(v);
+        setOpenaiKey(v);
+      },
       onSave: () => setOpenaiKey(openaiDraft),
       onRemove: () => {
         setOpenaiDraft("");


### PR DESCRIPTION
## Summary
- Remove automatic `process.env.OPENAI_API_KEY` fallback from assistant API routes, requiring an `Authorization` header or `apiKey` field instead
- Label the OpenAI key field as powering voice & text assistants and persist its value in the sidebar
- Document that local use requires setting the OpenAI key via the sidebar rather than environment variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a252ff62ec8321a537e454cff7a567