### PR TITLE
feat: add image input to voice assistant

### DIFF
--- a/src/api/assistant-voice.test.ts
+++ b/src/api/assistant-voice.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from "vitest";
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import handler from "../../api/assistant-voice";
+
+describe("assistant-voice input building", () => {
+  it("sends text and image content, ignoring invalid URLs", async () => {
+    let captured: any = null;
+    const fetchMock = vi.fn(async (_url: any, init: any) => {
+      captured = JSON.parse(init.body);
+      return {
+        ok: true,
+        json: async () => ({
+          output: [
+            {
+              content: [
+                { type: "text", text: "hi" },
+                { type: "audio", audio: { data: "xyz" } },
+              ],
+            },
+          ],
+        }),
+      } as any;
+    });
+    // @ts-ignore
+    global.fetch = fetchMock;
+
+    const req = {
+      method: "POST",
+      body: {
+        apiKey: "k",
+        prompt: "hello",
+        ctx: {
+          images: ["https://valid/image.png", "notaurl"],
+        },
+      },
+      headers: {},
+    } as unknown as VercelRequest;
+
+    const res: Partial<VercelResponse> = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+      setHeader: vi.fn(),
+      send: vi.fn(),
+    } as any;
+
+    await handler(req, res as VercelResponse);
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(captured.input).toBeTruthy();
+    const imgEntry = captured.input.find((p: any) =>
+      Array.isArray(p.content) && p.content.some((c: any) => c.type === "input_image"),
+    );
+    expect(imgEntry).toBeTruthy();
+    const urls = imgEntry.content.map((c: any) => c.image_url);
+    expect(urls).toEqual(["https://valid/image.png"]);
+  });
+});

--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -187,7 +187,21 @@ export async function askLLMVoice(
     apiKey,
     prompt: command,
   };
-  if (ctx) payload.ctx = ctx;
+  if (ctx) {
+    const images = Array.isArray(ctx.images)
+      ? ctx.images
+          .map((img: any) =>
+            typeof img === "string"
+              ? img
+              : img && typeof img.url === "string"
+                ? img.url
+                : undefined,
+          )
+          .filter((u): u is string => typeof u === "string")
+          .slice(0, 5)
+      : undefined;
+    payload.ctx = { ...ctx, ...(images ? { images } : {}) };
+  }
 
   const ac = new AbortController();
   const timeout = setTimeout(() => ac.abort(), 15_000);


### PR DESCRIPTION
## Summary
- allow assistant-voice API to send image URLs as `input_image` parts
- sanitize context images when calling voice LLM from client
- cover voice assistant input building with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a252f628b88321ae1163537f1b56ac