### PR TITLE
Fix audio response handling for voice assistant

### DIFF
--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -210,6 +210,13 @@ export async function askLLMVoice(
     }
 
     const { bytes, url, type } = await readAudioStream(res);
+    if (!bytes.length || !type.startsWith("audio")) {
+      const msg = "missing or invalid audio";
+      const toast = `Assistant voice request failed: ${msg}`;
+      bus.emit?.("toast", { message: toast });
+      bus.emit?.("notify", toast);
+      return { ok: false, error: msg };
+    }
     const text = res.headers.get("x-text") ?? undefined;
     return { ok: true, audio: bytes, url, type, text };
   } catch (e: any) {


### PR DESCRIPTION
## Summary
- return decoded MP3 bytes from `/api/assistant-voice` with `audio/mpeg` and transcript in `x-text`
- validate audio type and presence in `askLLMVoice`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2536729108321a9c1c117b992618b