### PR TITLE
feat: support image and selection inputs for voice

### DIFF
--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -236,8 +236,17 @@ export default function AssistantOrb() {
         : "")?.trim() || "";
     const images = post
       ? Array.isArray(post.images)
-        ? [...post.images]
-        : post.image
+        ? post.images
+            .filter((u): u is string => typeof u === "string")
+            .filter(
+              (u) =>
+                /^https?:\/\//i.test(u) ||
+                /^data:image\/[a-zA-Z]+;base64,/i.test(u),
+            )
+            .slice(0, 5)
+        : post.image &&
+            (/^https?:\/\//i.test(post.image) ||
+              /^data:image\/[a-zA-Z]+;base64,/i.test(post.image))
           ? [post.image]
           : []
       : [];


### PR DESCRIPTION
## Summary
- send selection text and images as structured inputs for voice responses
- validate and cap context images to five URLs client and server side

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a25368f5188321aada47b0d7b34097