### PR TITLE
refactor: send api key via header for voice

### DIFF
--- a/api/assistant-voice.ts
+++ b/api/assistant-voice.ts
@@ -29,14 +29,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       : "";
 
   const apiKey =
-    (headerKey || (typeof body.apiKey === "string" ? body.apiKey.trim() : "")) ||
-    (process.env.OPENAI_API_KEY || "");
+    headerKey || (typeof body.apiKey === "string" ? body.apiKey.trim() : "");
 
   if (!apiKey) {
     return res.status(401).json({
       ok: false,
-      error:
-        "Unauthorized: missing OpenAI API key. Provide one in the request or set OPENAI_API_KEY on the server.",
+      error: "Unauthorized: missing OpenAI API key.",
     });
   }
 

--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -300,11 +300,11 @@ export default function AssistantOrb() {
     const apiKey = getKey("openai");
     if (!apiKey) {
       bus.emit?.("sidebar:open");
-      setToast("Please set your OpenAI API key in the sidebar");
+      setToast("Add your OpenAI API key in the sidebar");
       push({
         id: uuid(),
         role: "assistant",
-        text: "⚠️ Please set your OpenAI API key in the sidebar.",
+        text: "⚠️ Add your OpenAI API key in the sidebar.",
         ts: Date.now(),
         postId: post?.id ?? null,
       });

--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -183,8 +183,7 @@ export async function askLLMVoice(
     return { ok: false, error: "missing api key" };
   }
 
-  const payload: { apiKey: string; prompt: string; ctx?: AssistantCtx } = {
-    apiKey,
+  const payload: { prompt: string; ctx?: AssistantCtx } = {
     prompt: command,
   };
   if (ctx) payload.ctx = ctx;
@@ -194,7 +193,10 @@ export async function askLLMVoice(
   try {
     const res = await fetch("/api/assistant-voice", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
       body: JSON.stringify(payload),
       signal: ac.signal,
     });


### PR DESCRIPTION
## Summary
- require request-supplied OpenAI key and return 401 if missing
- send OpenAI key using Authorization header in voice assistant helper
- remind users to add their OpenAI key in the sidebar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2536bade88321ab872d86470257f8