### PR TITLE
Fix emoji bars width for overflowing reactions

### DIFF
--- a/src/components/feed/postcard.css
+++ b/src/components/feed/postcard.css
@@ -121,6 +121,9 @@
 /* “pop-out” single-row emoji strip, extending from the glass */
 .pc-react-strip{
   display:flex; align-items:center; gap:8px; overflow-x:auto;
+  width:100%;
+  max-width:100%;
+  box-sizing:border-box;
   padding:6px 8px; border-radius:999px;
   background: var(--pc-glass); border:1px solid var(--pc-stroke);
   color: var(--pc-ink);

--- a/src/components/postcard.css
+++ b/src/components/postcard.css
@@ -114,6 +114,9 @@
 .pc-drawer-inner{ padding:12px 14px; max-width:100%; box-sizing:border-box; }
 .pc-emoji-bar{
   display:flex;
+  width:100%;
+  max-width:100%;
+  box-sizing:border-box;
   flex-wrap:nowrap;
   overflow-x:auto;
   -webkit-overflow-scrolling:touch;


### PR DESCRIPTION
## Summary
- Prevent reaction emoji bars from widening posts by setting width and box-sizing rules
- Apply the same fix to feed PostCard reaction strip

## Testing
- `npm test`
- Verified computed styles with jsdom to confirm width 100% and border-box


------
https://chatgpt.com/codex/tasks/task_e_68a253c330e48321b69669759fc55716