### PR TITLE
feat: add configurable fetch timeouts

### DIFF
--- a/src/lib/fetchWithTimeout.ts
+++ b/src/lib/fetchWithTimeout.ts
@@ -1,0 +1,23 @@
+export interface FetchTimeoutOptions extends RequestInit {
+  timeout?: number;
+}
+
+const DEFAULT_TIMEOUT = 15_000;
+
+export async function fetchWithTimeout(
+  input: RequestInfo | URL,
+  { timeout = DEFAULT_TIMEOUT, ...init }: FetchTimeoutOptions = {}
+): Promise<Response | null> {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeout);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } catch (e: unknown) {
+    if (e instanceof Error && e.name === "AbortError") {
+      return null;
+    }
+    throw e;
+  } finally {
+    clearTimeout(id);
+  }
+}

--- a/src/lib/imageProviders.ts
+++ b/src/lib/imageProviders.ts
@@ -1,5 +1,6 @@
 import { getKey as getStoredKey } from "./secureStore";
 import bus from "./bus";
+import { fetchWithTimeout } from "./fetchWithTimeout";
 
 export type FeedImage = {
   id: string;
@@ -49,8 +50,8 @@ function warnMissingKey(name: string) {
 /** PICSUM — no key needed */
 async function fetchPicsum(page: number, perPage: number): Promise<FeedImage[]> {
   const url = `https://picsum.photos/v2/list?page=${page}&limit=${perPage}`;
-  const res = await fetch(url);
-  if (!res.ok) return [];
+  const res = await fetchWithTimeout(url, { timeout: 10_000 });
+  if (!res || !res.ok) return [];
   let list: any[] = [];
   try {
     list = await res.json();
@@ -85,8 +86,11 @@ async function fetchUnsplash(page: number, perPage: number, query?: string): Pro
     orientation: "landscape",
     query: query || "",
   });
-  const res = await fetch(`${base}?${params.toString()}`, { headers: { Authorization: `Client-ID ${key}` } });
-  if (!res.ok) return [];
+  const res = await fetchWithTimeout(`${base}?${params.toString()}`, {
+    headers: { Authorization: `Client-ID ${key}` },
+    timeout: 10_000,
+  });
+  if (!res || !res.ok) return [];
   let json: any;
   try {
     json = await res.json();
@@ -117,8 +121,11 @@ async function fetchPexels(page: number, perPage: number, query?: string): Promi
     per_page: String(perPage),
     query: query || "",
   });
-  const res = await fetch(`${base}?${params.toString()}`, { headers: { Authorization: key } });
-  if (!res.ok) return [];
+  const res = await fetchWithTimeout(`${base}?${params.toString()}`, {
+    headers: { Authorization: key },
+    timeout: 10_000,
+  });
+  if (!res || !res.ok) return [];
   let json: any;
   try {
     json = await res.json();

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,9 +1,12 @@
+import { fetchWithTimeout } from "./fetchWithTimeout";
+
 export async function logError(error: unknown, info?: unknown) {
   try {
-    await fetch('/api/log', {
+    await fetchWithTimeout('/api/log', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ error: String(error), info }),
+      timeout: 5_000,
     });
   } catch {
     // ignore logging errors

--- a/src/lib/repost.ts
+++ b/src/lib/repost.ts
@@ -1,4 +1,5 @@
 import bus from "./bus";
+import { fetchWithTimeout } from "./fetchWithTimeout";
 
 export type Platform = 'x' | 'facebook' | 'linkedin';
 
@@ -19,16 +20,17 @@ export async function repost(
 ): Promise<boolean> {
   try {
     if (import.meta.env.PROD) {
-      const res = await fetch(`/api/repost/${platform}`, {
+      const res = await fetchWithTimeout(`/api/repost/${platform}`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ content }),
+        timeout: 10_000,
       });
 
-      if (!res.ok) {
-        throw new Error(`Request failed with status ${res.status}`);
+      if (!res || !res.ok) {
+        throw new Error(`Request failed${res ? ` with status ${res.status}` : ' due to timeout'}`);
       }
     } else {
       // eslint-disable-next-line no-console -- helpful during development

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,6 +1,7 @@
 // src/lib/search.ts
 import type { Post, SearchResult } from "../types";
 import { demoPosts } from "./placeholders";
+import { fetchWithTimeout } from "./fetchWithTimeout";
 
 export function localSearchPosts(q: string, posts?: Post[]): SearchResult[] {
   const data = posts?.length ? posts : demoPosts;
@@ -22,12 +23,13 @@ export function localSearchPosts(q: string, posts?: Post[]): SearchResult[] {
 // Optional: web search via your backend
 export async function webSearch(q: string): Promise<SearchResult[]> {
   try {
-    const res = await fetch("/api/search", {
+    const res = await fetchWithTimeout("/api/search", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ q }),
+      timeout: 10_000,
     });
-    if (!res.ok) return [];
+    if (!res || !res.ok) return [];
     const data = await res.json();
     return (data?.results || []) as SearchResult[];
   } catch { return []; }


### PR DESCRIPTION
## Summary
- add `fetchWithTimeout` helper that aborts fetch requests after a configurable delay
- update all API and client fetch calls to use the helper and return empty data or errors on timeout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a253e84db08321b68fa97e1b650fe4