### PR TITLE
Use Authorization header for assistant voice API key

### DIFF
--- a/api/assistant-voice.ts
+++ b/api/assistant-voice.ts
@@ -7,7 +7,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   const body = (req.body ?? {}) as {
-    apiKey?: string;
     prompt?: string;
     q?: string;
     model?: string; // e.g. "gpt-4o-mini-tts"
@@ -23,18 +22,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     };
   };
 
-  const headerKey =
+  const apiKey =
     typeof req.headers.authorization === "string"
       ? req.headers.authorization.replace(/^Bearer\s+/i, "").trim()
       : "";
-
-  const apiKey = headerKey || (typeof body.apiKey === "string" ? body.apiKey.trim() : "");
 
   if (!apiKey) {
     return res.status(401).json({
       ok: false,
       error:
-        "Unauthorized: missing OpenAI API key. Provide one in the request header or body.",
+        "Unauthorized: missing OpenAI API key. Provide one in the Authorization header.",
     });
   }
 

--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -309,11 +309,11 @@ export default function AssistantOrb() {
     const apiKey = getKey("openai");
     if (!apiKey) {
       bus.emit?.("sidebar:open");
-      setToast("Please set your OpenAI API key in the sidebar");
+      setToast("Set your OpenAI API key in the sidebar to use the assistant");
       push({
         id: uuid(),
         role: "assistant",
-        text: "⚠️ Please set your OpenAI API key in the sidebar.",
+        text: "⚠️ Set your OpenAI API key in the sidebar to use the assistant.",
         ts: Date.now(),
         postId: post?.id ?? null,
       });

--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -142,8 +142,7 @@ export async function askLLMVoice(
     return { ok: false, error: "missing api key" };
   }
 
-  const payload: { apiKey: string; prompt: string; ctx?: AssistantCtx } = {
-    apiKey,
+  const payload: { prompt: string; ctx?: AssistantCtx } = {
     prompt: command,
   };
   if (ctx) payload.ctx = ctx;
@@ -153,7 +152,10 @@ export async function askLLMVoice(
   try {
     const res = await fetch("/api/assistant-voice", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
       body: JSON.stringify(payload),
       signal: ac.signal,
     });


### PR DESCRIPTION
## Summary
- require OpenAI API key via `Authorization` header in `/api/assistant-voice`
- send API key in header in `askLLMVoice`
- prompt users in AssistantOrb to set their OpenAI key in the sidebar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2554819788321aeefccb96fefd705