### PR TITLE
feat: validate openai key

### DIFF
--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -163,6 +163,18 @@
   width: 100%;
 }
 
+.key-status {
+  display: flex;
+  align-items: center;
+  font-size: 1.25rem;
+}
+.key-status.success {
+  color: #22c55e;
+}
+.key-status.error {
+  color: #ef4444;
+}
+
 @media (max-width: 400px) {
   .key-input {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- verify OpenAI API key using `/api/openai-ping`
- surface toast on failure and show green check on success

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a25795facc8321ad8e4f747c4b776d