### PR TITLE
feat: responsive assistant orb

### DIFF
--- a/src/components/AssistantOrb.css
+++ b/src/components/AssistantOrb.css
@@ -1,5 +1,6 @@
 
 :root {
+  --orb-size: clamp(60px, 10vw, 76px);
   --orb-bg: radial-gradient(
     120% 120% at 30% 30%,
     #fff,
@@ -24,6 +25,7 @@
     0 0 30px color-mix(in srgb, var(--orb-color) 30%, transparent),
     var(--orb-shadow), 0 0 0 8px var(--orb-ring);
   animation: orbPulse 3s ease-in-out infinite;
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
   backdrop-filter: blur(14px) saturate(140%);
   transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
   touch-action: none;
@@ -152,5 +154,33 @@
   bottom: calc(100% + 4px);
   top: auto;
   transform: none;
+}
+
+@media (max-width: 480px) {
+  .assistant-orb__toast {
+    font-size: clamp(10px, 2.5vw, 12px);
+    padding: 4px 6px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .assistant-orb,
+  .assistant-orb__core::before,
+  .assistant-orb__core::after,
+  .assistant-orb.mic .assistant-orb__ring {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+
+@media (prefers-contrast: more) {
+  .assistant-orb {
+    box-shadow:
+      0 0 0 2px var(--orb-ring),
+      0 0 20px color-mix(in srgb, var(--orb-color) 80%, transparent),
+      var(--orb-shadow), 0 0 0 8px var(--orb-ring);
+    -webkit-backdrop-filter: blur(12px) saturate(160%);
+    backdrop-filter: blur(12px) saturate(160%);
+  }
 }
 

--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -20,13 +20,16 @@ import { getKey } from "../lib/secureStore";
  */
 
 
-const ORB_SIZE = 76;
-const ORB_MARGIN = 12;
-const DRAG_THRESHOLD = 5;
-const PANEL_WIDTH = 360;
-const STORAGE_KEY = "assistantOrbPos.v6";
-
 const clamp = (n: number, a: number, b: number) => Math.min(b, Math.max(a, n));
+
+// Derive sizes from the viewport rather than hard-coded pixels so the orb
+// scales sensibly on phones and large screens. Use fallbacks for SSR/tests.
+const vw = typeof window === "undefined" ? 1024 : window.innerWidth;
+const ORB_SIZE = clamp(vw * 0.1, 56, 76);            // 10vw, min 56px, max 76px
+const ORB_MARGIN = clamp(vw * 0.02, 8, 16);          // 2vw, min 8px
+const DRAG_THRESHOLD = clamp(vw * 0.01, 4, 10);      // 1vw, min 4px
+const PANEL_WIDTH = clamp(vw * 0.8, 260, 360);       // 80vw, max 360px
+const STORAGE_KEY = "assistantOrbPos.v6";
 const uuid = () => {
   try {
     return globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
@@ -638,6 +641,11 @@ export default function AssistantOrb() {
   const keyframes = `
     @keyframes panelIn { from { opacity: 0; transform: scale(.97) translateY(8px); } to { opacity: 1; transform: scale(1) translateY(0); } }
   `;
+
+  const isSmall =
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(max-width: 480px)").matches;
   const orbStyle: React.CSSProperties = {
     position: "fixed",
     left: 0, top: 0,
@@ -652,17 +660,19 @@ export default function AssistantOrb() {
       ? "0 18px 44px rgba(255,116,222,0.24), 0 0 0 12px rgba(255,116,222,0.12)"
       : "0 12px 30px rgba(0,0,0,.35)",
     willChange: "transform",
-    transition: dragging ? "none" : "box-shadow .2s ease, filter .2s ease",
+    backdropFilter: "blur(14px) saturate(140%)",
+    WebkitBackdropFilter: "blur(14px) saturate(140%)",
+    transition: reduceMotion || dragging ? "none" : "box-shadow .2s ease, filter .2s ease",
     cursor: dragging ? "grabbing" : "grab",
     transform: `translate3d(${pos.x}px, ${pos.y}px, 0)`,
   };
   const coreStyle: React.CSSProperties = {
-    width: 56, height: 56, borderRadius: 999,
+    width: ORB_SIZE - 20, height: ORB_SIZE - 20, borderRadius: 999,
     background: "radial-gradient(60% 60% at 40% 35%, rgba(255,255,255,.95), rgba(255,255,255,.28) 65%, transparent 70%)",
     pointerEvents: "none",
   };
   const ringStyle: React.CSSProperties = {
-    position: "absolute", inset: -6, borderRadius: 999, pointerEvents: "none",
+    position: "absolute", inset: -(ORB_SIZE * 0.08), borderRadius: 999, pointerEvents: "none",
   };
   const overlayStyle: React.CSSProperties = {
     position: "fixed",
@@ -673,23 +683,26 @@ export default function AssistantOrb() {
     position: "fixed",
     background: "rgba(0,0,0,.7)",
     color: "#fff",
-    padding: "6px 10px",
-    borderRadius: 10,
-    fontSize: 13,
+    padding: isSmall ? "4px 6px" : "6px 10px",
+    borderRadius: isSmall ? 8 : 10,
+    fontSize: isSmall ? 11 : 13,
     zIndex: 9998,
     pointerEvents: "none",
   };
   const panelStyle: React.CSSProperties = {
     position: "fixed",
-    width: PANEL_WIDTH, maxWidth: "90vw",
+    width: PANEL_WIDTH,
+    maxWidth: "90vw",
     background: "linear-gradient(180deg, rgba(255,255,255,.03), rgba(255,255,255,.02))",
     border: "1px solid rgba(255,255,255,.06)",
-    borderRadius: 14,
-    padding: 12,
+    borderRadius: isSmall ? 10 : 14,
+    padding: isSmall ? 8 : 12,
+    fontSize: isSmall ? 14 : 16,
     zIndex: 9998,
     boxShadow: "0 16px 40px rgba(0,0,0,.45)",
     backdropFilter: "blur(10px) saturate(140%)",
-    animation: "panelIn .2s ease-out",
+    WebkitBackdropFilter: "blur(10px) saturate(140%)",
+    animation: reduceMotion ? undefined : "panelIn .2s ease-out",
   };
 
   function handleOrbKeyDown(e: React.KeyboardEvent) {

--- a/src/components/orbConstants.ts
+++ b/src/components/orbConstants.ts
@@ -1,3 +1,14 @@
 export const HOLD_MS = 280;
-export const MOVE_TOLERANCE = 8;
-export const SNAP_PADDING = 12;
+
+// Use viewport-based sizing for gesture tolerances so the orb feels
+// consistent across devices. Fall back to sensible defaults when
+// `window` is unavailable (SSR/tests).
+const vw = typeof window === "undefined" ? 1000 : window.innerWidth;
+
+// How far the pointer can move (in px) before a press is cancelled.
+// Previously this was a hard-coded 8px.
+export const MOVE_TOLERANCE = Math.max(6, vw * 0.01); // ≈1vw
+
+// Padding from the screen edge when snapping the orb into place.
+// Previously this was a hard-coded 12px.
+export const SNAP_PADDING = Math.max(10, vw * 0.015); // ≈1.5vw


### PR DESCRIPTION
## Summary
- scale assistant orb with viewport-based clamp values
- adjust orb toast and panel spacing for small screens
- add reduced-motion and high-contrast CSS fallbacks with consistent blur

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a257af0d0c83218de5c5c3cd8e6046