### PR TITLE
chore: update anchor recalculation

### DIFF
--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -71,14 +71,20 @@ export default function AssistantOrb() {
     };
   });
   const setPos = (v: React.SetStateAction<{ x: number; y: number }>) => {
-    if (mountedRef.current) _setPos(v);
+    if (mountedRef.current) {
+      _setPos(v);
+      requestAnimationFrame(updateAnchors);
+    }
   };
   const posRef = useRef<{ x: number; y: number }>({ ...pos });
 
   // UI
   const [open, _setOpen] = useState(false);       // chat panel
   const setOpen = (v: React.SetStateAction<boolean>) => {
-    if (mountedRef.current) _setOpen(v);
+    if (mountedRef.current) {
+      _setOpen(v);
+      requestAnimationFrame(updateAnchors);
+    }
   };
   const [mic, _setMic] = useState(false);
   const setMic = (v: React.SetStateAction<boolean>) => {
@@ -601,7 +607,8 @@ export default function AssistantOrb() {
   }, [menuOpen]);
 
   useEffect(() => {
-    const onResize = () => {
+    let resizeTimer: number | null = null;
+    const handleResize = () => {
       if (typeof window === "undefined") return;
       const nx = clamp(posRef.current.x, ORB_MARGIN, window.innerWidth - ORB_SIZE - ORB_MARGIN);
       const ny = clamp(posRef.current.y, ORB_MARGIN, window.innerHeight - ORB_SIZE - ORB_MARGIN);
@@ -609,6 +616,10 @@ export default function AssistantOrb() {
       setPos({ x: nx, y: ny });
       applyTransform(nx, ny);
       updateAnchors();
+    };
+    const onResize = () => {
+      if (resizeTimer != null) window.clearTimeout(resizeTimer);
+      resizeTimer = window.setTimeout(handleResize, 100);
     };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
@@ -621,8 +632,14 @@ export default function AssistantOrb() {
     };
 
     window.addEventListener("resize", onResize);
+    window.addEventListener("orientationchange", onResize);
     window.addEventListener("keydown", onKey);
-    return () => { window.removeEventListener("resize", onResize); window.removeEventListener("keydown", onKey); };
+    return () => {
+      window.removeEventListener("resize", onResize);
+      window.removeEventListener("orientationchange", onResize);
+      window.removeEventListener("keydown", onKey);
+      if (resizeTimer != null) window.clearTimeout(resizeTimer);
+    };
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- refresh anchors when orb moves or panel toggles
- debounce resize/orientation events and handle orientation changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a257a4e2ec8321b5a0689fdf911c62