### PR TITLE
refactor: centralize assistant context builder

### DIFF
--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import bus from "../lib/bus";
 import { logError } from "../lib/logger";
-import { askLLMVoice, buildCtx } from "../lib/assistant";
+import { askLLMVoice, buildAssistantContext } from "../lib/assistant";
 import useSpeech from "../lib/useSpeech";
 import type { AssistantMessage, Post } from "../types";
 import RadialMenu from "./RadialMenu";
@@ -238,7 +238,7 @@ export default function AssistantOrb() {
 
   async function handleCommand(text: string) {
     const post = ctxPost || null;
-    const ctx = buildCtx(post, ctxPostText);
+    const ctx = buildAssistantContext(post, ctxPostText);
 
     push({ id: uuid(), role: "user", text, ts: Date.now(), postId: post?.id ?? null });
 

--- a/src/lib/assistant.test.ts
+++ b/src/lib/assistant.test.ts
@@ -4,9 +4,9 @@ vi.mock("./secureStore", () => ({
   getKey: () => "test-key",
 }));
 
-import { askLLM, askLLMVoice, buildCtx } from "./assistant";
+import { askLLM, askLLMVoice, buildAssistantContext } from "./assistant";
 
-describe("buildCtx", () => {
+describe("buildAssistantContext", () => {
   it("includes selection and images", () => {
     const sel = "selected text";
     vi.spyOn(window, "getSelection").mockReturnValue({
@@ -21,7 +21,7 @@ describe("buildCtx", () => {
       ],
       title: "T",
     } as any;
-    const ctx = buildCtx(post, "post text");
+    const ctx = buildAssistantContext(post, "post text");
     expect(ctx).not.toBeNull();
     if (!ctx) throw new Error("ctx should not be null");
     expect(ctx.selection).toBe(sel);

--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -21,7 +21,7 @@ function getPostText(p: Post | null): string {
   }
 }
 
-export function buildCtx(
+export function buildAssistantContext(
   post: Post | null,
   postTextOverride?: string,
 ): AssistantCtx {


### PR DESCRIPTION
## Summary
- add `buildAssistantContext` helper to gather post info, selected text, and images
- use `buildAssistantContext` in `AssistantOrb.handleCommand` for consistent context building
- update tests to use the new context helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a259be7ed083218cdaeea5271d9c8e