### PR TITLE
refactor voice assistant to call OpenAI responses API directly

### DIFF
--- a/src/lib/assistant.test.ts
+++ b/src/lib/assistant.test.ts
@@ -112,11 +112,27 @@ describe("askLLMVoice", () => {
   it("forwards context selection and images", async () => {
     const mockFetch = vi.fn(async (_url: any, init: any) => {
       const body = JSON.parse(init.body);
-      expect(body.ctx.selection).toBe("sel");
-      expect(body.ctx.images).toEqual(["https://img.jpg"]);
+      // Ensure the selection and image were embedded into the input array
+      const selectionMsg = body.input.find((m: any) =>
+        JSON.stringify(m).includes("User selected text: sel"),
+      );
+      expect(selectionMsg).toBeTruthy();
+      const imageMsg = body.input.find((m: any) =>
+        Array.isArray(m.content) && m.content.some((c: any) => c.image_url === "https://img.jpg"),
+      );
+      expect(imageMsg).toBeTruthy();
       return {
         ok: true,
-        json: async () => ({ audio: "aGVsbG8=", text: "hi", type: "audio/mpeg" }),
+        json: async () => ({
+          output: [
+            {
+              content: [
+                { type: "audio", audio: { data: "aGVsbG8=" } },
+                { type: "text", text: "hi" },
+              ],
+            },
+          ],
+        }),
       } as any;
     });
     // @ts-ignore

--- a/src/lib/assistantVoice.test.ts
+++ b/src/lib/assistantVoice.test.ts
@@ -23,7 +23,16 @@ describe("askLLMVoice", () => {
     const audioB64 = Buffer.from("hi").toString("base64");
     global.fetch = vi.fn(async () => ({
       ok: true,
-      json: async () => ({ audio: audioB64, text: "hello", type: "audio/mpeg" }),
+      json: async () => ({
+        output: [
+          {
+            content: [
+              { type: "audio", audio: { data: audioB64 } },
+              { type: "text", text: "hello" },
+            ],
+          },
+        ],
+      }),
     })) as any;
 
     const res = await askLLMVoice("test");
@@ -47,7 +56,7 @@ describe("askLLMVoice", () => {
       });
     }) as any;
     const p = askLLMVoice("test");
-    vi.advanceTimersByTime(16000);
+    vi.advanceTimersByTime(46000);
     const res = await p;
     expect(res.ok).toBe(false);
     if (res.ok) throw new Error("expected fail");


### PR DESCRIPTION
## Summary
- send voice requests directly to `https://api.openai.com/v1/responses` using stored key
- embed post context, selections, and images in request payload
- fall back to existing `/api/assistant-voice` endpoint when direct call fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a259bccaac8321b507b43054b8c66b