### PR TITLE
Remove deprecated modalities parameter from voice endpoint

### DIFF
--- a/api/assistant-voice.ts
+++ b/api/assistant-voice.ts
@@ -141,7 +141,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       },
       body: JSON.stringify({
         model,
-        modalities: ["text", "audio"],
         input,
         audio: { voice, format: "mp3", ...(speed ? { speed } : {}) },
         temperature: 0.3,


### PR DESCRIPTION
## Summary
- remove deprecated `modalities` from assistant-voice API request

## Testing
- `npm test`
- `curl -v -X POST https://api.openai.com/v1/responses ...` *(fails: CONNECT tunnel 403, but no `Unknown parameter: modalities` error)*

------
https://chatgpt.com/codex/tasks/task_e_68a25bd6def88321954d791694d5603e