### PR TITLE
Add mobile-friendly ChatDock with minimize toggle

### DIFF
--- a/src/components/ChatDock.css
+++ b/src/components/ChatDock.css
@@ -1,0 +1,72 @@
+.chat-dock {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 90vw;
+  height: 70vh;
+  max-width: 480px;
+  max-height: 600px;
+  background: #fff;
+  color: #000;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  z-index: 1000;
+}
+
+.chat-dock-header {
+  padding: 8px;
+  border-bottom: 1px solid #ddd;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.chat-dock-close,
+.chat-dock-minimize {
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.chat-dock-messages {
+  flex: 1;
+  overflow: auto;
+  padding: 8px;
+}
+
+.chat-dock-message {
+  margin-bottom: 4px;
+}
+
+.chat-dock-icon {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  margin: 8px;
+  border: 1px solid #ccc;
+  background: #fff;
+  border-radius: 50%;
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  cursor: pointer;
+}
+
+@media (max-width: 768px) {
+  .chat-dock {
+    top: auto;
+    left: 0;
+    bottom: 0;
+    transform: none;
+    width: 100%;
+    height: auto;
+    max-height: 50vh;
+    border-radius: 8px 8px 0 0;
+  }
+}

--- a/src/components/ChatDock.tsx
+++ b/src/components/ChatDock.tsx
@@ -1,6 +1,12 @@
 // src/components/ChatDock.tsx
-import React, { createContext, useContext, useState, ReactNode } from "react";
+import React, {
+  createContext,
+  useContext,
+  useState,
+  ReactNode,
+} from "react";
 import type { AssistantMessage } from "../types";
+import "./ChatDock.css";
 
 type ChatDockContextValue = {
   open: boolean;
@@ -53,6 +59,7 @@ export default function ChatDock({
   const ctx = useContext(ChatDockContext);
   const open = openProp ?? ctx?.open ?? false;
   const messages = messagesProp ?? ctx?.messages ?? [];
+  const [minimized, setMinimized] = useState(false);
 
   const handleClose = () => {
     ctx?.closeDock?.();
@@ -61,46 +68,41 @@ export default function ChatDock({
 
   if (!open) return null;
 
-  return (
-    <div
-      className="chat-dock"
-      style={{
-        position: "fixed",
-        top: "50%",
-        left: "50%",
-        transform: "translate(-50%, -50%)",
-        width: "90vw",
-        height: "70vh",
-        maxWidth: "480px",
-        maxHeight: "600px",
-        background: "#fff",
-        color: "#000",
-        display: "flex",
-        flexDirection: "column",
-        border: "1px solid #ccc",
-        borderRadius: "8px",
-        zIndex: 1000,
-      }}
-    >
-      <div style={{ padding: "8px", borderBottom: "1px solid #ddd" }}>
-        <button
-          aria-label="Close chat"
-          onClick={handleClose}
-          style={{ float: "right", border: "none", background: "none" }}
-        >
-          ×
-        </button>
-        <strong>Chat</strong>
-      </div>
-      <div
-        style={{
-          flex: 1,
-          overflow: "auto",
-          padding: "8px",
-        }}
+  if (minimized)
+    return (
+      <button
+        className="chat-dock-icon"
+        aria-label="Open chat"
+        onClick={() => setMinimized(false)}
       >
+        💬
+      </button>
+    );
+
+  return (
+    <div className="chat-dock">
+      <div className="chat-dock-header">
+        <strong>Chat</strong>
+        <div>
+          <button
+            aria-label="Minimize chat"
+            className="chat-dock-minimize"
+            onClick={() => setMinimized(true)}
+          >
+            _
+          </button>
+          <button
+            aria-label="Close chat"
+            className="chat-dock-close"
+            onClick={handleClose}
+          >
+            ×
+          </button>
+        </div>
+      </div>
+      <div className="chat-dock-messages">
         {messages.map((m) => (
-          <div key={m.id} style={{ marginBottom: "4px" }}>
+          <div key={m.id} className="chat-dock-message">
             <b>{m.role === "assistant" ? "Assistant" : "You"}:</b> {m.text}
           </div>
         ))}


### PR DESCRIPTION
## Summary
- Move ChatDock styles into `ChatDock.css` with responsive rules for desktop and mobile
- Replace inline positioning styles and allow mobile dock to sit at bottom with 50vh max height
- Add minimize button that collapses the dock to a chat icon

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a25f4b8d1c8321af6971d866a8bd16