### PR TITLE
Consolidate assistant actions in radial menu

### DIFF
--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -121,10 +121,6 @@ export default function AssistantOrb() {
   const setMenuOpen = (v: React.SetStateAction<boolean>) => {
     if (mountedRef.current) _setMenuOpen(v);
   };
-  const [petal, _setPetal] = useState<null | "comment" | "remix" | "share">(null);
-  const setPetal = (v: React.SetStateAction<null | "comment" | "remix" | "share">) => {
-    if (mountedRef.current) _setPetal(v);
-  };
   const [voiceOn, _setVoiceOn] = useState(true);
   const setVoiceOn = (v: React.SetStateAction<boolean>) => {
     if (mountedRef.current) _setVoiceOn(v);
@@ -373,6 +369,32 @@ export default function AssistantOrb() {
     bus.emit?.("post:react", { id: ctxPost.id, emoji });
     setToast(`Reacted ${emoji}`);
     window.setTimeout(() => setToast(""), 900);
+  }
+
+  function handleComment() {
+    if (!ctxPost) { setToast("Hover a post first"); return; }
+    const body = window.prompt("Write a comment");
+    if (!body) return;
+    bus.emit?.("post:comment", { id: ctxPost.id, body });
+    setToast("Commented");
+    window.setTimeout(() => setToast(""), 900);
+  }
+
+  function handleRemix() {
+    if (!ctxPost) { setToast("Hover a post first"); return; }
+    bus.emit?.("post:remix", { id: ctxPost.id });
+    setToast("Remixing");
+    window.setTimeout(() => setToast(""), 900);
+  }
+
+  async function handleShare() {
+    if (!ctxPost) { setToast("Hover a post first"); return; }
+    try {
+      const url = `${location.origin}${location.pathname}#post-${ctxPost.id}`;
+      await navigator.clipboard.writeText(url);
+      setToast("Link copied");
+      window.setTimeout(() => setToast(""), 900);
+    } catch {}
   }
 
   // hover highlight
@@ -625,7 +647,6 @@ export default function AssistantOrb() {
       if (e.key === "Escape") {
         setOpen(false);
         setMenuOpen(false);
-        setPetal(null);
         stopListening();
         orbRef.current?.focus();
       }
@@ -732,15 +753,19 @@ export default function AssistantOrb() {
       setMenuOpen(true);
     } else if (k === "c") {
       e.preventDefault();
-      setPetal("comment"); setMenuOpen(false);
+      handleComment();
+      setMenuOpen(false);
     } else if (k === "m") {
       e.preventDefault();
-      setPetal("remix"); setMenuOpen(false);
+      handleRemix();
+      setMenuOpen(false);
     } else if (k === "s") {
       e.preventDefault();
-      setPetal("share"); setMenuOpen(false);
+      handleShare();
+      setMenuOpen(false);
     } else if (e.key === "Escape") {
-      setMenuOpen(false); setPetal(null); stopListening();
+      setMenuOpen(false);
+      stopListening();
       orbRef.current?.focus();
     }
   }
@@ -821,7 +846,6 @@ export default function AssistantOrb() {
             style={overlayStyle}
             onClick={() => {
               setMenuOpen(false);
-              setPetal(null);
               orbRef.current?.focus();
             }}
           />
@@ -833,7 +857,6 @@ export default function AssistantOrb() {
             }}
             onChat={() => {
               setOpen(v => !v);
-              setPetal(null);
               setMenuOpen(false);
               requestAnimationFrame(updateAnchors);
             }}
@@ -842,15 +865,15 @@ export default function AssistantOrb() {
               setMenuOpen(false);
             }}
             onComment={() => {
-              setPetal("comment");
+              handleComment();
               setMenuOpen(false);
             }}
             onRemix={() => {
-              setPetal("remix");
+              handleRemix();
               setMenuOpen(false);
             }}
             onShare={() => {
-              setPetal("share");
+              handleShare();
               setMenuOpen(false);
             }}
             onProfile={() => {
@@ -972,61 +995,6 @@ export default function AssistantOrb() {
         </div>
       )}
 
-      {/* Petal drawers */}
-      {petal && (
-        <div className="assistant-petal">
-          <div className="ap-head">
-            <div className="ap-dot" />
-            <div className="ap-title">{petal === "comment" ? "Comment" : petal === "remix" ? "Remix" : "Share"}</div>
-            <div className="ap-sub">{ctxPost ? `Post ${ctxPost.id}` : "Hover a post to target"}</div>
-            <button className="ap-btn" onClick={() => setPetal(null)}>Close</button>
-          </div>
-
-          {petal === "comment" && (
-            <form
-              className="ap-form"
-              onSubmit={(e) => {
-                e.preventDefault();
-                const input = (e.currentTarget.elements.namedItem("cmt") as HTMLInputElement);
-                const t = input.value.trim();
-                if (!t || !ctxPost) return;
-                bus.emit?.("post:comment", { id: ctxPost.id, body: t });
-                input.value = "";
-                setPetal(null);
-              }}
-            >
-              <input className="ap-input" name="cmt" placeholder="Write a comment…" />
-              <button className="ap-send" type="submit">Send</button>
-            </form>
-          )}
-
-          {petal === "remix" && (
-            <div className="ap-body">
-              <div className="ap-hint">Make a quick remix of the current post. Uses defaults.</div>
-              <button className="ap-btn" onClick={() => { if (ctxPost) { bus.emit?.("post:remix", { id: ctxPost.id }); setPetal(null); } }}>
-                Remix 🎬
-              </button>
-            </div>
-          )}
-
-          {petal === "share" && (
-            <div className="ap-body">
-              <div className="ap-hint">Copy link to this post.</div>
-              <button
-                className="ap-btn"
-                onClick={async () => {
-                  if (!ctxPost) return;
-                  const url = `${location.origin}${location.pathname}#post-${ctxPost.id}`;
-                  try { await navigator.clipboard.writeText(url); setToast("Link copied"); setTimeout(() => setToast(""), 900); } catch {}
-                  setPetal(null);
-                }}
-              >
-                Copy Link ↗️
-              </button>
-            </div>
-          )}
-        </div>
-      )}
     </>
   );
 }

--- a/src/components/RadialMenu.test.tsx
+++ b/src/components/RadialMenu.test.tsx
@@ -86,7 +86,9 @@ describe("RadialMenu keyboard navigation", () => {
     const menus = getAllByRole("menu");
     const menu = menus[menus.length - 1];
 
-    // cycle through the four root items to focus the close control
+    // cycle through the six root items to focus the close control
+    fireEvent.keyDown(menu, { key: "ArrowRight" });
+    fireEvent.keyDown(menu, { key: "ArrowRight" });
     fireEvent.keyDown(menu, { key: "ArrowRight" });
     fireEvent.keyDown(menu, { key: "ArrowRight" });
     fireEvent.keyDown(menu, { key: "ArrowRight" });

--- a/src/components/RadialMenu.tsx
+++ b/src/components/RadialMenu.tsx
@@ -72,7 +72,7 @@ export default function RadialMenu(props: RadialMenuProps) {
   } = props;
 
   const menuRef = useRef<HTMLDivElement | null>(null);
-  const [subMenu, setSubMenu] = useState<"react" | "create" | null>(null);
+  const [subMenu, setSubMenu] = useState<"react" | null>(null);
   const [index, setIndex] = useState(0);
   const reduceMotion = useReducedMotion();
 
@@ -135,34 +135,6 @@ export default function RadialMenu(props: RadialMenuProps) {
         },
       },
       { id: "react", label: "React", icon: "👏", next: "react" as const },
-      { id: "create", label: "Create", icon: "✍️", next: "create" as const },
-      {
-        id: "profile",
-        label: "Profile",
-        icon: (
-          <img
-            src={avatarUrl}
-            alt=""
-            aria-hidden="true"
-            style={{ width: "100%", height: "100%", objectFit: "cover" }}
-          />
-        ),
-        action: () => {
-          onProfile();
-          onClose();
-        },
-      },
-    ],
-    react: emojis.map((e, i) => ({
-      id: `emoji-${i}`,
-      label: `React ${e}`,
-      icon: e,
-      action: () => {
-        onReact(e);
-        onClose();
-      },
-    })),
-    create: [
       {
         id: "comment",
         label: "Comment",
@@ -190,15 +162,35 @@ export default function RadialMenu(props: RadialMenuProps) {
           onClose();
         },
       },
+      {
+        id: "profile",
+        label: "Profile",
+        icon: (
+          <img
+            src={avatarUrl}
+            alt=""
+            aria-hidden="true"
+            style={{ width: "100%", height: "100%", objectFit: "cover" }}
+          />
+        ),
+        action: () => {
+          onProfile();
+          onClose();
+        },
+      },
     ],
+    react: emojis.map((e, i) => ({
+      id: `emoji-${i}`,
+      label: `React ${e}`,
+      icon: e,
+      action: () => {
+        onReact(e);
+        onClose();
+      },
+    })),
   } as const;
 
-  const ringItems =
-    subMenu === null
-      ? menuConfig.root
-      : subMenu === "react"
-      ? menuConfig.react
-      : menuConfig.create;
+  const ringItems = subMenu === null ? menuConfig.root : menuConfig.react;
 
   const centerItem =
     subMenu === null


### PR DESCRIPTION
## Summary
- expose Comment, Remix, and Share directly from the assistant radial menu alongside Chat and React
- remove legacy petal drawers and handle comment, remix, share actions inline from the orb
- adjust radial menu tests for increased root items

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a25f35a1088321bf2d43c3c935da55