### PR TITLE
Add modalities to assistant voice API request

### DIFF
--- a/api/assistant-voice.ts
+++ b/api/assistant-voice.ts
@@ -142,6 +142,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       body: JSON.stringify({
         model,
         input,
+        modalities: ["text", "audio"],
         audio: { voice, format: "mp3", ...(speed ? { speed } : {}) },
         temperature: 0.3,
       }),


### PR DESCRIPTION
## Summary
- include `modalities: ["text", "audio"]` in `/api/assistant-voice` fetch request body so it matches the client

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a260e7b8788321aafcaa307d290960