### PR TITLE
fix: remove unsupported modalities from voice request

### DIFF
--- a/api/assistant-voice.ts
+++ b/api/assistant-voice.ts
@@ -142,7 +142,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       body: JSON.stringify({
         model,
         input,
-        modalities: ["text", "audio"],
         audio: { voice, format: "mp3", ...(speed ? { speed } : {}) },
         temperature: 0.3,
       }),


### PR DESCRIPTION
## Summary
- drop `modalities` param from assistant-voice API request to align with Responses API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a26425ac2c8321b01db35f0ec0e64e